### PR TITLE
Update StationHub version and Flatpak runtime version

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <packageSources>
-        <add key="LocalNugetPackages" value="/run/build/StationHub/LocalNugetPackages" />
-    </packageSources>
+    <!--packageSources>
+        <add key="nuget-sources" value="/run/build/StationHub/nuget-sources" />
+    </packageSources-->
     <disabledPackageSources>
         <add key="nuget.org" value="true" />
     </disabledPackageSources>

--- a/nuget.config
+++ b/nuget.config
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <!--packageSources>
-        <add key="nuget-sources" value="/run/build/StationHub/nuget-sources" />
-    </packageSources-->
     <disabledPackageSources>
         <add key="nuget.org" value="true" />
     </disabledPackageSources>

--- a/org.unitystation.StationHub.yaml
+++ b/org.unitystation.StationHub.yaml
@@ -4,7 +4,7 @@ runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 command: stationhub.sh
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.dotnet
+  - org.freedesktop.Sdk.Extension.dotnet6
 finish-args:
   - --socket=x11
   - --share=ipc

--- a/org.unitystation.StationHub.yaml
+++ b/org.unitystation.StationHub.yaml
@@ -33,7 +33,7 @@ modules:
       - sources.json
     buildsystem: simple
     build-commands:
-      - '. /usr/lib/sdk/dotnet6/enable.sh; dotnet publish --framework net6.0 --runtime linux-x64 --configuration Release --self-contained true --property PublishDir=/app/bin ./UnitystationLauncher/UnitystationLauncher.csproj /p:DefineConstants="FLATPAK"'
+      - '. /usr/lib/sdk/dotnet6/enable.sh; dotnet publish --framework net6.0 --runtime linux-x64 --configuration Release --self-contained true --source ./nuget-sources --property PublishDir=/app/bin ./UnitystationLauncher/UnitystationLauncher.csproj /p:DefineConstants="FLATPAK"'
       - install -D UnitystationLauncher/Assets/org.unitystation.StationHub.desktop /app/share/applications/org.unitystation.StationHub.desktop
       - install -D UnitystationLauncher/Assets/Ian64.png /app/share/icons/hicolor/64x64/apps/org.unitystation.StationHub.png
       - install -D UnitystationLauncher/Assets/Ian128.png /app/share/icons/hicolor/128x128/apps/org.unitystation.StationHub.png

--- a/org.unitystation.StationHub.yaml
+++ b/org.unitystation.StationHub.yaml
@@ -2,7 +2,7 @@ app-id: org.unitystation.StationHub
 runtime: org.freedesktop.Platform
 runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
-command: stationhub.sh
+command: StationHub
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.dotnet6
 finish-args:
@@ -23,10 +23,6 @@ modules:
         url: https://github.com/iputils/iputils
         tag: 20221126
         commit: 5ffabc4190cab975c7332645259e286a032e183b
-  - name: dotnet
-    buildsystem: simple
-    build-commands:
-    - /usr/lib/sdk/dotnet/install.sh
   - name: StationHub
     sources:
       - type: git
@@ -38,9 +34,13 @@ modules:
         path: stationhub.sh
       - sources.json
     buildsystem: simple
+    build-options:
+      - append-path: /usr/lib/sdk/dotnet6/bin
+        append-ld-library-path: /usr/lib/sdk/dotnet6/lib
+        env:
+          - PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/sdk/dotnet6/lib/pkgconfig
     build-commands:
-      - '. /usr/lib/sdk/dotnet/enable.sh; dotnet publish --framework net6.0 --runtime linux-x64 --configuration Release --self-contained --property PublishDir=/app/org.unitystation.StationHub ./UnitystationLauncher/UnitystationLauncher.csproj /p:DefineConstants="FLATPAK"'
-      - install -D stationhub.sh /app/bin/stationhub.sh
+      - '. /usr/lib/sdk/dotnet/enable.sh; dotnet publish --framework net6.0 --runtime linux-x64 --configuration Release --self-contained true --property PublishDir=/app/bin ./UnitystationLauncher/UnitystationLauncher.csproj /p:DefineConstants="FLATPAK"'
       - install -D UnitystationLauncher/Assets/org.unitystation.StationHub.desktop /app/share/applications/org.unitystation.StationHub.desktop
       - install -D UnitystationLauncher/Assets/Ian64.png /app/share/icons/hicolor/64x64/apps/org.unitystation.StationHub.png
       - install -D UnitystationLauncher/Assets/Ian128.png /app/share/icons/hicolor/128x128/apps/org.unitystation.StationHub.png

--- a/org.unitystation.StationHub.yaml
+++ b/org.unitystation.StationHub.yaml
@@ -32,12 +32,8 @@ modules:
         path: nuget.config
       - sources.json
     buildsystem: simple
-    build-options:
-      - append-path: /usr/lib/sdk/dotnet6/bin
-        append-ld-library-path: /usr/lib/sdk/dotnet6/lib
-        env:
-          - PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/sdk/dotnet6/lib/pkgconfig
     build-commands:
+      - /usr/lib/sdk/dotnet6/enable.sh
       - dotnet publish --framework net6.0 --runtime linux-x64 --configuration Release --self-contained true --property PublishDir=/app/bin ./UnitystationLauncher/UnitystationLauncher.csproj /p:DefineConstants="FLATPAK"
       - install -D UnitystationLauncher/Assets/org.unitystation.StationHub.desktop /app/share/applications/org.unitystation.StationHub.desktop
       - install -D UnitystationLauncher/Assets/Ian64.png /app/share/icons/hicolor/64x64/apps/org.unitystation.StationHub.png

--- a/org.unitystation.StationHub.yaml
+++ b/org.unitystation.StationHub.yaml
@@ -17,10 +17,7 @@ modules:
     config-opts:
       - -DBUILD_ARPING=false
       - -DBUILD_CLOCKDIFF=false
-      - -DBUILD_NINFOD=false
-      - -DBUILD_RDISC=false
       - -DBUILD_TRACEPATH=false
-      - -DENABLE_RDISC_SERVER=false
     sources:
       - type: git
         url: https://github.com/iputils/iputils

--- a/org.unitystation.StationHub.yaml
+++ b/org.unitystation.StationHub.yaml
@@ -33,7 +33,7 @@ modules:
       - sources.json
     buildsystem: simple
     build-commands:
-      - /usr/lib/sdk/dotnet6/enable.sh; dotnet publish --framework net6.0 --runtime linux-x64 --configuration Release --self-contained true --property PublishDir=/app/bin ./UnitystationLauncher/UnitystationLauncher.csproj /p:DefineConstants="FLATPAK"
+      - '. /usr/lib/sdk/dotnet6/enable.sh; dotnet publish --framework net6.0 --runtime linux-x64 --configuration Release --self-contained true --property PublishDir=/app/bin ./UnitystationLauncher/UnitystationLauncher.csproj /p:DefineConstants="FLATPAK"'
       - install -D UnitystationLauncher/Assets/org.unitystation.StationHub.desktop /app/share/applications/org.unitystation.StationHub.desktop
       - install -D UnitystationLauncher/Assets/Ian64.png /app/share/icons/hicolor/64x64/apps/org.unitystation.StationHub.png
       - install -D UnitystationLauncher/Assets/Ian128.png /app/share/icons/hicolor/128x128/apps/org.unitystation.StationHub.png

--- a/org.unitystation.StationHub.yaml
+++ b/org.unitystation.StationHub.yaml
@@ -38,7 +38,7 @@ modules:
         env:
           - PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/sdk/dotnet6/lib/pkgconfig
     build-commands:
-      - '. /usr/lib/sdk/dotnet/enable.sh; dotnet publish --framework net6.0 --runtime linux-x64 --configuration Release --self-contained true --property PublishDir=/app/bin ./UnitystationLauncher/UnitystationLauncher.csproj /p:DefineConstants="FLATPAK"'
+      - dotnet publish --framework net6.0 --runtime linux-x64 --configuration Release --self-contained true --property PublishDir=/app/bin ./UnitystationLauncher/UnitystationLauncher.csproj /p:DefineConstants="FLATPAK"
       - install -D UnitystationLauncher/Assets/org.unitystation.StationHub.desktop /app/share/applications/org.unitystation.StationHub.desktop
       - install -D UnitystationLauncher/Assets/Ian64.png /app/share/icons/hicolor/64x64/apps/org.unitystation.StationHub.png
       - install -D UnitystationLauncher/Assets/Ian128.png /app/share/icons/hicolor/128x128/apps/org.unitystation.StationHub.png

--- a/org.unitystation.StationHub.yaml
+++ b/org.unitystation.StationHub.yaml
@@ -33,8 +33,7 @@ modules:
       - sources.json
     buildsystem: simple
     build-commands:
-      - /usr/lib/sdk/dotnet6/enable.sh
-      - dotnet publish --framework net6.0 --runtime linux-x64 --configuration Release --self-contained true --property PublishDir=/app/bin ./UnitystationLauncher/UnitystationLauncher.csproj /p:DefineConstants="FLATPAK"
+      - /usr/lib/sdk/dotnet6/enable.sh; dotnet publish --framework net6.0 --runtime linux-x64 --configuration Release --self-contained true --property PublishDir=/app/bin ./UnitystationLauncher/UnitystationLauncher.csproj /p:DefineConstants="FLATPAK"
       - install -D UnitystationLauncher/Assets/org.unitystation.StationHub.desktop /app/share/applications/org.unitystation.StationHub.desktop
       - install -D UnitystationLauncher/Assets/Ian64.png /app/share/icons/hicolor/64x64/apps/org.unitystation.StationHub.png
       - install -D UnitystationLauncher/Assets/Ian128.png /app/share/icons/hicolor/128x128/apps/org.unitystation.StationHub.png

--- a/org.unitystation.StationHub.yaml
+++ b/org.unitystation.StationHub.yaml
@@ -27,7 +27,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/unitystation/stationhub
-        commit: cdbfb50a04501c5ddb747b52ebbae08fadd1f011
+        commit: 28856113558903e165fabc8b071b4111924acb7e
       - type: file
         path: nuget.config
       - type: file

--- a/org.unitystation.StationHub.yaml
+++ b/org.unitystation.StationHub.yaml
@@ -1,6 +1,6 @@
 app-id: org.unitystation.StationHub
 runtime: org.freedesktop.Platform
-runtime-version: '20.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 command: stationhub.sh
 sdk-extensions:
@@ -24,7 +24,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/iputils/iputils
-        tag: s20200821
+        tag: 20221126
+        commit: 5ffabc4190cab975c7332645259e286a032e183b
   - name: dotnet
     buildsystem: simple
     build-commands:
@@ -32,8 +33,8 @@ modules:
   - name: StationHub
     sources:
       - type: git
-        url: https://github.com/Elijahrane/stationhub/
-        branch: develop
+        url: https://github.com/unitystation/stationhub
+        commit: cdbfb50a04501c5ddb747b52ebbae08fadd1f011
       - type: file
         path: nuget.config
       - type: file
@@ -41,13 +42,11 @@ modules:
       - sources.json
     buildsystem: simple
     build-commands:
-      - '. /usr/lib/sdk/dotnet/enable.sh; dotnet publish -c Release ./UnitystationLauncher/UnitystationLauncher.csproj /p:DefineConstants="FLATPAK"'
-      - cp -R UnitystationLauncher/bin/Release/netcoreapp3.1/ /app/org.unitystation.StationHub
-      - cp -R /usr/lib/sdk/dotnet /app/dotnet
+      - '. /usr/lib/sdk/dotnet/enable.sh; dotnet publish --framework net6.0 --runtime linux-x64 --configuration Release --self-contained --property PublishDir=/app/org.unitystation.StationHub ./UnitystationLauncher/UnitystationLauncher.csproj /p:DefineConstants="FLATPAK"'
       - install -D stationhub.sh /app/bin/stationhub.sh
-      - install -D  UnitystationLauncher/Assets/org.unitystation.StationHub.desktop /app/share/applications/org.unitystation.StationHub.desktop
-      - install -D  UnitystationLauncher/Assets/Ian64.png /app/share/icons/hicolor/64x64/apps/org.unitystation.StationHub.png
-      - install -D  UnitystationLauncher/Assets/Ian128.png /app/share/icons/hicolor/128x128/apps/org.unitystation.StationHub.png
-      - install -D  UnitystationLauncher/Assets/Ian256.png /app/share/icons/hicolor/256x256/apps/org.unitystation.StationHub.png
-      - install -D  UnitystationLauncher/Assets/Ian512.png /app/share/icons/hicolor/512x512/apps/org.unitystation.StationHub.png
-      - install -D  UnitystationLauncher/Assets/org.unitystation.StationHub.metainfo.xml /app/share/metainfo/org.unitystation.StationHub.metainfo.xml
+      - install -D UnitystationLauncher/Assets/org.unitystation.StationHub.desktop /app/share/applications/org.unitystation.StationHub.desktop
+      - install -D UnitystationLauncher/Assets/Ian64.png /app/share/icons/hicolor/64x64/apps/org.unitystation.StationHub.png
+      - install -D UnitystationLauncher/Assets/Ian128.png /app/share/icons/hicolor/128x128/apps/org.unitystation.StationHub.png
+      - install -D UnitystationLauncher/Assets/Ian256.png /app/share/icons/hicolor/256x256/apps/org.unitystation.StationHub.png
+      - install -D UnitystationLauncher/Assets/Ian512.png /app/share/icons/hicolor/512x512/apps/org.unitystation.StationHub.png
+      - install -D UnitystationLauncher/Assets/org.unitystation.StationHub.metainfo.xml /app/share/metainfo/org.unitystation.StationHub.metainfo.xml

--- a/org.unitystation.StationHub.yaml
+++ b/org.unitystation.StationHub.yaml
@@ -30,8 +30,6 @@ modules:
         commit: 28856113558903e165fabc8b071b4111924acb7e
       - type: file
         path: nuget.config
-      - type: file
-        path: stationhub.sh
       - sources.json
     buildsystem: simple
     build-options:

--- a/org.unitystation.StationHub.yaml
+++ b/org.unitystation.StationHub.yaml
@@ -27,7 +27,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/unitystation/stationhub
-        commit: 28856113558903e165fabc8b071b4111924acb7e
+        commit: 45f68bef1e83e004262534e52c8c4f7119fc89b6
       - type: file
         path: nuget.config
       - sources.json

--- a/org.unitystation.StationHub.yaml
+++ b/org.unitystation.StationHub.yaml
@@ -33,7 +33,7 @@ modules:
       - sources.json
     buildsystem: simple
     build-commands:
-      - '. /usr/lib/sdk/dotnet6/enable.sh; dotnet publish --framework net6.0 --runtime linux-x64 --configuration Release --self-contained true --source ./nuget-sources --property PublishDir=/app/bin ./UnitystationLauncher/UnitystationLauncher.csproj /p:DefineConstants="FLATPAK"'
+      - '. /usr/lib/sdk/dotnet6/enable.sh; dotnet publish --framework net6.0 --runtime linux-x64 --configuration Release --self-contained true --source ./nuget-sources --property PublishDir=/app/bin ./UnitystationLauncher/UnitystationLauncher.csproj /p:DefineConstants="FLATPAK" /p:DisableBeauty=true'
       - install -D UnitystationLauncher/Assets/org.unitystation.StationHub.desktop /app/share/applications/org.unitystation.StationHub.desktop
       - install -D UnitystationLauncher/Assets/Ian64.png /app/share/icons/hicolor/64x64/apps/org.unitystation.StationHub.png
       - install -D UnitystationLauncher/Assets/Ian128.png /app/share/icons/hicolor/128x128/apps/org.unitystation.StationHub.png

--- a/sources.json
+++ b/sources.json
@@ -1,2221 +1,1724 @@
 [
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.xml.xpath/4.0.1/system.xml.xpath.4.0.1.nupkg",
-        "sha512": "af1b4150aff0f6e20bf4a73889d9b3e12b282d87ec6be88681cb78a8958eadaaadbc907ddad0856850fa4eee165e76b176e42ea866aeefbd6e323bfad6f26d64",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.xml.xpath.4.0.1.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/autofac/6.5.0/autofac.6.5.0.nupkg",
+        "sha512": "cb8cf3e770d0924fdac19f884cc569e2f93639f57538f0097b7b019b54624f8c1530f1bd0efd1edecac8a95d41c75d105dab4bb32dcb935a4714835b8a3f9e0f",
+        "dest": "nuget-sources",
+        "dest-filename": "autofac.6.5.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.xml.xpath.xdocument/4.0.1/system.xml.xpath.xdocument.4.0.1.nupkg",
-        "sha512": "237e12e54077b7bbb26a656925ce75360f0f426f12a0ddba628cc869a876558eb04247d857d6649c017dc84e3e5c734397bcb3b28da27d7fe1c97f79ecff50fa",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.xml.xpath.xdocument.4.0.1.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/autofacserilogintegration/5.0.0/autofacserilogintegration.5.0.0.nupkg",
+        "sha512": "7b8ec04f0c305c00a55e842f2383361af26ec924e59f8c653a6dfaa531660bf549efe9cf63093bdb0900fa47ae6d06e3788ecc60049bffa9fc1c918e14c664cf",
+        "dest": "nuget-sources",
+        "dest-filename": "autofacserilogintegration.5.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.codepages/4.0.1/system.text.encoding.codepages.4.0.1.nupkg",
-        "sha512": "da68445fffcffa0a8b8f2bdab880ec4cbe51dd66209ab455cf6f16166efdf31b47498e852f616b3b7ba0dd11209e05a2625cca6fb07fafa20a945cc501282026",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.text.encoding.codepages.4.0.1.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia/0.10.18/avalonia.0.10.18.nupkg",
+        "sha512": "bfa398495373162d13add9a15c4b65016a08b5405206d45225952ac202ad66fa7e5d157ce3bbf19d78b00389a33e32dee697884144b0678af7f61508826ceb5c",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.0.10.18.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.xml.xmldocument/4.0.1/system.xml.xmldocument.4.0.1.nupkg",
-        "sha512": "bf29bec129c8ea3fca70ff8357adcd24ade2db855c57c16459832c6e4489427f2959c70ae64fc860d2d3d41e3fe6d4df77c751fbbe8106099a8a0cd5fb38af7d",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.xml.xmldocument.4.0.1.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.angle.windows.natives/2.1.0.2020091801/avalonia.angle.windows.natives.2.1.0.2020091801.nupkg",
+        "sha512": "185412856ea8f3001b19ff03261fa84d3b7b529a2a0eb0a0eada93eac5761e11056f2080373ac5a11449250aadcf61631875e4ca8d5ac5f0e7ef39bd09e93430",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.angle.windows.natives.2.1.0.2020091801.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.fileversioninfo/4.0.0/system.diagnostics.fileversioninfo.4.0.0.nupkg",
-        "sha512": "b6fb4fb753787c36114807039d0fa1f406d9e6a1b5cb6aca3f309d226565ad415cc0aa8247ff4ee8a60cf56ce8d656ba4ca7748c53bb3fd0e3ca4ca4a808e0e1",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.diagnostics.fileversioninfo.4.0.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.avaloniaedit/0.10.0/avalonia.avaloniaedit.0.10.0.nupkg",
+        "sha512": "d347422e75645ffac5c5b7a735cfd4762fa27ca464072daa2165009e24bedf38387a71d59f8e4aed463fa6c61643caa5a31def8e28f61f86bcee5c07177fc6f3",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.avaloniaedit.0.10.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.stacktrace/4.0.1/system.diagnostics.stacktrace.4.0.1.nupkg",
-        "sha512": "3abedfd73dfdd40d8b6b594f5fb5748696d69f34b464546d4689d2be3370f0f7d2f9e645018f78ffc678db319b24ead35eee5ab62d2d1d26ae0db84224632b6e",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.diagnostics.stacktrace.4.0.1.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.controls.datagrid/0.10.18/avalonia.controls.datagrid.0.10.18.nupkg",
+        "sha512": "44f28349f55156448fea48ea5999d13cc7ab23ed4105ddeccf8b4ee8bb9f05dafe6be3a9375db843758eab17cf3a0efb282ab76896cd6befbfa887c7bc9231ee",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.controls.datagrid.0.10.18.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.analyzers/1.1.0/microsoft.codeanalysis.analyzers.1.1.0.nupkg",
-        "sha512": "12d7a033ec66d072c9249677fb0712446290991a587b180e6d18ffef0eb97b738443fe69098370984ee56eba9f6ca0bbe57d11ac59d41a32d137c7f9a6734aac",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.codeanalysis.analyzers.1.1.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.desktop/0.10.18/avalonia.desktop.0.10.18.nupkg",
+        "sha512": "c33d01e4e766a1bdcf642100bff4cf1c5a868736375a2dd5305c131e265e1cfe69a0d1b2ea4f83104434a066cee33c391bd5968b707ad0699992c0b1662ff118",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.desktop.0.10.18.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.io.compression/4.1.0/runtime.native.system.io.compression.4.1.0.nupkg",
-        "sha512": "453e16348b435b0d8bc5c4db85d77c99f6e4a79f62e8168eb91c972d6e788c8f1f965ba6e46c1b42f71dee4618373ac70499024f6a4d1462c040fe4989f68283",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.native.system.io.compression.4.1.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.diagnostics/0.10.18/avalonia.diagnostics.0.10.18.nupkg",
+        "sha512": "14ba2ec4aa8ca1756d8a766b48af226fc978502656dff50789bceb064112fb6c4ca7db492f3ebf66fb40b49a9e96d1b8ccafca12587691e2f1b2d57cc5a8d756",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.diagnostics.0.10.18.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.io.compression/4.3.0/runtime.native.system.io.compression.4.3.0.nupkg",
-        "sha512": "bff1f0cac94327014bb07c1ebee06c216e6e4951b1ddaa0c8a753a4a0338be621fd15ec621503490dbca54a75809abc4f420669b33052b28d24d726ac79c9891",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.native.system.io.compression.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.freedesktop/0.10.18/avalonia.freedesktop.0.10.18.nupkg",
+        "sha512": "ce5edac45a9069ec62cbb843ad4ae310ad407785b6ad8afe23bf98c6b28ab9b6d067f313f0432db605e0c9e444ceaad8f77f7dda1839bd3e97da635cbd9e6afa",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.freedesktop.0.10.18.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.dotnethost/1.0.1/microsoft.netcore.dotnethost.1.0.1.nupkg",
-        "sha512": "7998499a697f483bbebb7ba360e7aae3b03edcc530af1391a009c648279566dfdced9720cfdc0466a13b9d15ec349402fc1b3e6738ab0fed64a7018e741e9d1d",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.netcore.dotnethost.1.0.1.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.native/0.10.18/avalonia.native.0.10.18.nupkg",
+        "sha512": "9bba27cbd6b0082157ed3f5c3d8d02a11f98e4148aef11062daee11c4f763919e89e1bbe124581bcfd611151faecc037835f38099ee026467e5c07ce094ba522",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.native.0.10.18.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.common/1.3.0/microsoft.codeanalysis.common.1.3.0.nupkg",
-        "sha512": "ae29716477d0f7a34fc43298a8e71685362cef144def7d1554dcdac5efcd49686e8e03aaad411d972ebb087bd4529106683258ea201826d81aca1b8071ab218e",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.codeanalysis.common.1.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.reactiveui/0.10.18/avalonia.reactiveui.0.10.18.nupkg",
+        "sha512": "5243514a25a9ab72f39ca86b515156129bd3e785930136f7352439bb91f099def3e02c6af18f56c83b21091c6d6607789a56a10be44e076f4be3f3ea7c7c7a01",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.reactiveui.0.10.18.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.xml.xdocument/4.0.11/system.xml.xdocument.4.0.11.nupkg",
-        "sha512": "f8ae902901963f2636f39c0652d82daa9df3fb3e3d5a60493c39f6cf01ed07c7d57f175a2d2895f4a872d4e92527e5131522218d1a67da2fd491e162273a8527",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.xml.xdocument.4.0.11.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.remote.protocol/0.10.18/avalonia.remote.protocol.0.10.18.nupkg",
+        "sha512": "3d4ccc0821212b7e13dce1a7bdd2fd616ad18c111989389080cd95922198ed3aa57617740aff08c77c15f65c5790373be752614fe2956efbbeb133a2f9b2d358",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.remote.protocol.0.10.18.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.xml.xdocument/4.3.0/system.xml.xdocument.4.3.0.nupkg",
-        "sha512": "c2d9236a696daf23a29b530b9aa510fb813041685a1bb9a95845a51e61d870a0615e988b150f5be0d0896ef94b123e97f96c8a43ee815cf5b9897593986b1113",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.xml.xdocument.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.skia/0.10.18/avalonia.skia.0.10.18.nupkg",
+        "sha512": "eb60286c911526e60366e21aa3f99a439a916144f24ec99e050007f125cc8e45bafd9963bdd6cc4c897f35369aefacfb42976fff5ba795c80b0405027523fa7c",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.skia.0.10.18.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.xml.readerwriter/4.0.11/system.xml.readerwriter.4.0.11.nupkg",
-        "sha512": "d40d6e9d55e57acdf04132bcb8ae8abf1abb3483620cde969c78c6c393a9936abf742c1dcf66288e6e9dffcb399a880ee3c11540ac140cb32e20b41365aaf35e",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.xml.readerwriter.4.0.11.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.win32/0.10.18/avalonia.win32.0.10.18.nupkg",
+        "sha512": "4d5218edbb80420c9b90052bc1a6ecff2d8bb05598fb9bf93c7496ac196de4d3b83d3b52c286a1ccfa3c68117df32fb9789c492f8abb90c4bb457e108908a58d",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.win32.0.10.18.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.xml.readerwriter/4.3.0/system.xml.readerwriter.4.3.0.nupkg",
-        "sha512": "991101497fbd39e43fc306ca280a465318868afa8db1f34bb87c266fe61f0c81a0ec34a797b236ee823bd60d1149b7592def96fe044abb511858efffe890c2e6",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.xml.readerwriter.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.x11/0.10.18/avalonia.x11.0.10.18.nupkg",
+        "sha512": "3dd443fb5436c7362eac851527a08710a5d02d9fcca93b8d1667dcb2d9e477ef814e674285eef415cc52ac98f22b6cfe1f364462fc064052b0de666778acd4da",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.x11.0.10.18.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.interopservices.runtimeinformation/4.0.0/system.runtime.interopservices.runtimeinformation.4.0.0.nupkg",
-        "sha512": "462d35e66cbdd21dc007f06c6ef129ab57e810fa0f0416bd2fc6fb7eed55138780d4d31e31ee6267a82e2e3a1607e5c642bd6efeb130b57a1baa87e3141b0080",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.runtime.interopservices.runtimeinformation.4.0.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/dotnet.bundle/0.9.13/dotnet.bundle.0.9.13.nupkg",
+        "sha512": "78ec815d14483e71237648c7ba1e2d07623ac45894ff797739da4cd406429fdea362ea630481bcd37d04b9c6fbdff252cde05fe1b1562acd80408268c8f924c1",
+        "dest": "nuget-sources",
+        "dest-filename": "dotnet.bundle.0.9.13.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.interopservices.runtimeinformation/4.3.0/system.runtime.interopservices.runtimeinformation.4.3.0.nupkg",
-        "sha512": "6f4905329a3cc9e62d274c885f275ee31c5af57a6c9fd1a5080d039cb748e0277bef3dc8ce42863cac78365084e00a032279bf3d2b7254a49f3fb1566a29ad1b",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.runtime.interopservices.runtimeinformation.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/dynamicdata/7.1.1/dynamicdata.7.1.1.nupkg",
+        "sha512": "a3149883c3c9f2218fe4117c8bfdc04b19d03f0bc5d47b5b7fcfc96cccf81849f7b91addb6a9ec88c1e5cffd2e9862b6b8907359994dfef431308ee78b025edf",
+        "dest": "nuget-sources",
+        "dest-filename": "dynamicdata.7.1.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.sockets/4.1.0/system.net.sockets.4.1.0.nupkg",
-        "sha512": "b231a1ca9d281923ffa1b8dbafa2cc074ce679fc2d473ad7c7192cdc3b51c8ab125c606cbbe0248e02b415e384bfba1bdbc59b28a139589c78aa3687e0236019",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.net.sockets.4.1.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/firebaseauthentication.net/3.7.2/firebaseauthentication.net.3.7.2.nupkg",
+        "sha512": "442230b591f94fbb5c0fddd299dc92372e2a62ed9af0ce3536ec123872a592f539d3fb52357b3d78917970ffa7d8bc4b5bb3f488f7e97effcdf74c136d88e174",
+        "dest": "nuget-sources",
+        "dest-filename": "firebaseauthentication.net.3.7.2.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.sockets/4.3.0/system.net.sockets.4.3.0.nupkg",
-        "sha512": "e32ed9518e9630e99edcf1963c3d0e7047ea8252853c9260eb5403a4206170ae28fd27eb239f39da4d2db766f830b3ebdc9e4da2e697be20241d928082200955",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.net.sockets.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/2.8.2.1-preview.108/harfbuzzsharp.2.8.2.1-preview.108.nupkg",
+        "sha512": "3de9e6ea186df99fd9a6d1d48908cc3d36ac9b7d1d16dfe5adef99b29d43eab6cd27b5ac85479d054b6cdc05cc92acdd981dfa1d46bfafedda3d83b28394cbe5",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.2.8.2.1-preview.108.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.compression.zipfile/4.0.1/system.io.compression.zipfile.4.0.1.nupkg",
-        "sha512": "49322ce411efafb4b55d43b0d7a52bc334990e1e45b321d01f0f394cf1aaba15845603d6f08a12c8f09454a03518e6c0ab7996ba73b1116c5c7f685d768bc62c",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.io.compression.zipfile.4.0.1.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.linux/2.8.2.1-preview.108/harfbuzzsharp.nativeassets.linux.2.8.2.1-preview.108.nupkg",
+        "sha512": "8935254107ec9580e920d810f4b5e9c2e2b6088bab7ccbd41a17b6da77a0b47b0be08f9d75d2c320b9b98c2753c00cb7955504786988d3254d3fdea18c46a3d8",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.nativeassets.linux.2.8.2.1-preview.108.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.compression.zipfile/4.3.0/system.io.compression.zipfile.4.3.0.nupkg",
-        "sha512": "1860634672767f818f0192ec2b2750693f0d39390f3b7d400cc6fd4f6e74a5cbed27bf49e5980ec85ff3e161c30f6190f700e339a1040c1699b87eb4aa7b6792",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.io.compression.zipfile.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/2.8.2.1-preview.108/harfbuzzsharp.nativeassets.macos.2.8.2.1-preview.108.nupkg",
+        "sha512": "dde20e55f099d3de444d03d1a0da1fe074d8a074b32c43b8ba0e3a2d45fa66fb48b9db2c9a790183111634e3edbf67065a4501f036df9fbbd3fbf870db8c342f",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.nativeassets.macos.2.8.2.1-preview.108.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.compression/4.1.0/system.io.compression.4.1.0.nupkg",
-        "sha512": "2402b7ba4f0b43bb916cbfd608f9efdb9f60406d2a19cd9e7a677867806962c30b5666b6270b873ff9748b4fc3f7fd6e0451f2a5214d5478593f57d4d8430979",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.io.compression.4.1.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.webassembly/2.8.2.1-preview.108/harfbuzzsharp.nativeassets.webassembly.2.8.2.1-preview.108.nupkg",
+        "sha512": "da78dd24556af8562b2ee4e53e49e7c17ba31f0a16e7b7a588371bdcf26a52af73fb60887253b6bc2e1e69dee94d38feb1730de0ad718753260120599b0ceee2",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.nativeassets.webassembly.2.8.2.1-preview.108.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.compression/4.3.0/system.io.compression.4.3.0.nupkg",
-        "sha512": "f540ee51a3bb6941cdfbaace9a9738d7f7986a2f94770db61f45a88ecb7ef36b571d4c07417dc89cdbe9655a262b7cc599b0a4b78effea91819e186121b44807",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.io.compression.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/2.8.2.1-preview.108/harfbuzzsharp.nativeassets.win32.2.8.2.1-preview.108.nupkg",
+        "sha512": "4ce79a68b383b466b690fcede1986103c2d88b99a92114e90ba32e07d802fe8436949272b4992bf366a0fbfa452699b9715532ab0ddb7746a3c4cc431a30a737",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.nativeassets.win32.2.8.2.1-preview.108.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tools/4.0.1/system.diagnostics.tools.4.0.1.nupkg",
-        "sha512": "a812ccbbdd0a66eb57075121ea6332a526803ef883ca9f8b06431d6668ad50efd13624fa87dfaf6aed03c652f795c2ffb9fa9d9895a2fafa96eca614cbf86cdb",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.diagnostics.tools.4.0.1.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer/2.14.1/humanizer.2.14.1.nupkg",
+        "sha512": "c167af0a6287547e3d4e0d16b31f15742816d0284acafb21dde5e5c8baade8b8ae92343687d311cdcd9fe8991a96ba24c1cdf2eb7bc4d4910feee1a6e454158a",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tools/4.3.0/system.diagnostics.tools.4.3.0.nupkg",
-        "sha512": "164d6977e721cbceb44ede7bfd75b03b8d9771e0426aefa5d40c71867e964092fdc6a6808bcbc5559ed73ec2c532ca657d6476af79a49ca3ad879b8366f13d90",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.diagnostics.tools.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core/2.14.1/humanizer.core.2.14.1.nupkg",
+        "sha512": "cb3a8653f1ca34b67d52fafa92f49cdf0615fd2e4efc8be4948516e5617b32e8af18b63cc12e486672cf92dec3d4a5bc12dd849e5d08dcbce0daf196336e17b3",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/morelinq/3.3.2/morelinq.3.3.2.nupkg",
-        "sha512": "15a97158c7ec83cf909aa4acc5e40f58344e1bceb4da93ea35c0bde9182be176f4d7198617438fbe73d63e5ede99dd46b84c069fbc461891e5b38339b607f2c6",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "morelinq.3.3.2.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.af/2.14.1/humanizer.core.af.2.14.1.nupkg",
+        "sha512": "ab9dc8bc4382544e4dd36c069babac009c5b801bcd6fa9ce7a12340e593e8d95736a661016bb628db7b5ce3ce5648776b3896cbc4b24cef6d6b07c8950f1d2b8",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.af.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.globalization.calendars/4.3.0/runtime.any.system.globalization.calendars.4.3.0.nupkg",
-        "sha512": "19053b502b7160af6f6b0bc5b334a8d124f77f6b4418993294fb485d0bb318cd6e97cdbda9bf8c9927366288413cad7209c9d8156a5425a6320c453a8804fb3d",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.any.system.globalization.calendars.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.ar/2.14.1/humanizer.core.ar.2.14.1.nupkg",
+        "sha512": "6819c2473a8139007322b400f814e93c5c8be8c6d6d436ebf976b32af1d1d4b7a9ffc55bb5502ef9e92d2c8de4ab14269df6064ef2c496b56e85bb0ad7d5b0be",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.ar.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.reflection.primitives/4.3.0/runtime.any.system.reflection.primitives.4.3.0.nupkg",
-        "sha512": "a2f374276290ad9b799d3e49cd8fe7839c07b52f22894bcd77b9470841564319fb2ebbd7503e76feef42db4e8a362af8648cf0842a1cb0b5d9a60a58ef8b205e",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.any.system.reflection.primitives.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.az/2.14.1/humanizer.core.az.2.14.1.nupkg",
+        "sha512": "c035548aae4f2a2d005818769cf3270a95892cbd513a49306af7b2f49e7e173fbadf06bd658e4f8522e9b61059ac0d05b48edb4a429cf8765ed9a6407974736c",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.az.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.globalization/4.3.0/runtime.any.system.globalization.4.3.0.nupkg",
-        "sha512": "3aac1a076212fae7d0ac81d2b5fdf216b064a1d890577307f89c9a4984c239838c3bdfac4dea052027de090704839319231eef49ce542f3e8bb2f85ba23d28dc",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.any.system.globalization.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.bg/2.14.1/humanizer.core.bg.2.14.1.nupkg",
+        "sha512": "d448737436a11a0d35c1ccafcd326e6ef687b492d0a3fb7335403e3b6094bec16e6a817f228930a708925917d4546a068365ab045ba566b10d7a47ad2243680f",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.bg.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.io/4.3.0/runtime.any.system.io.4.3.0.nupkg",
-        "sha512": "7e0d4a238322d434a19afc79ea988d3727c1687fdd5bcd1c4c39cb6201073caabb924cc201c70545d60acf8b94cde8b783d0c268743e040c357d100677e4c5ed",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.any.system.io.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.bn-bd/2.14.1/humanizer.core.bn-bd.2.14.1.nupkg",
+        "sha512": "84854ac0f8142072c22077a74fc1ef82d4d232ff050e792c776a78465153ecc5b7dbc85635fa64b905cfb04193c369a07f285f7d3bc77514b0afe166c8d17faf",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.bn-bd.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.diagnostics.tools/4.3.0/runtime.any.system.diagnostics.tools.4.3.0.nupkg",
-        "sha512": "bd257401e179d4b836a4a2f7236a0e303ae997d2453c946bf272036620a0b14e85e5f42c229332930a954655ab4cae359d191a3e3d9746df09535a651367764c",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.any.system.diagnostics.tools.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.cs/2.14.1/humanizer.core.cs.2.14.1.nupkg",
+        "sha512": "e97cb1fa2a9eec1e1e711f0aabc5cae14ddd67887db65c50d8255eeba02e18c37863226bdf7ee8a0d17bd38862781ba7331a5d50d44df9a5ec359de1e8a32479",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.cs.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.runtime.handles/4.3.0/runtime.any.system.runtime.handles.4.3.0.nupkg",
-        "sha512": "95cdae2867a2182535bd0f4d01dc3eff70319dff044b070ab7791fa2bf8688a69b00a279ed569b7f0c5f3e26bf705303dc344ecf7d1ea014c579436d8e7b7389",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.any.system.runtime.handles.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.da/2.14.1/humanizer.core.da.2.14.1.nupkg",
+        "sha512": "df63ffe161a5375835be00938f89f439c3eb06543d82c933885218b0366531ef8cd2a63ece9504e1463ad37e623a34ea3efcac40ff6309b88418857f5c544461",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.da.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.text.encoding/4.3.0/runtime.any.system.text.encoding.4.3.0.nupkg",
-        "sha512": "cbe6df98acd50e2251d3343620c408af56cfe7c1979277a8ec65b5eef093e93ed93c05980902a7152ed83302d5a625d7058921baa7f446c5e67194fa4c06f20a",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.any.system.text.encoding.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.de/2.14.1/humanizer.core.de.2.14.1.nupkg",
+        "sha512": "72802cf8b635582c2ee15de34d6f96da5983481d8262f73826068a94c479c7ecee68579167fc2e3665c004e7b7276edb5f292c5902d945594101670d3949e4d7",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.de.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.reflection/4.3.0/runtime.any.system.reflection.4.3.0.nupkg",
-        "sha512": "293d3dd8be87e1c5cd76ece4ed64ebb5ae6b50be95a39bee401eeed64355e34641905f8c14392fbc3acf8609f5d6fca731f39ce7607962eb5951f09516480015",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.any.system.reflection.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.el/2.14.1/humanizer.core.el.2.14.1.nupkg",
+        "sha512": "4ce5a5c15f087e0eaa3abe712b1f5909ce79b2caf365f12c1c72950a678a3ec2a69a57641fb6d4284f21e0ed97c1d82a99fc516c17cbdfec26b058652d0e3847",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.el.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.console/4.0.0/system.console.4.0.0.nupkg",
-        "sha512": "44937dfe632127d3a7c89ca77502eeb6f66201ef135384e04b570a90a3eee3d72497869344c759c35295d6a4b46afd561ba19562dfff9896ecf2d4b07e96fb9b",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.console.4.0.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.es/2.14.1/humanizer.core.es.2.14.1.nupkg",
+        "sha512": "4e6c7e561ef6d9ff871b0d90174582f5e2903a38e81dd6bdfcbb2315dd50d36a83d19e308befe7351ac9b75115f7af6d282a1c1444942b5b3d34951aa2a6ef1e",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.es.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.console/4.3.0/system.console.4.3.0.nupkg",
-        "sha512": "a08a684a583c9b3278ce32be1007dae495f9d87254666392f794ef1203079f333cd7d388c28944ffa36fb49f0c8bb21f42c70f6e1d7c1c03920df6d0d1130c82",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.console.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.fa/2.14.1/humanizer.core.fa.2.14.1.nupkg",
+        "sha512": "09e2e32538307b9da55c86952def9b57a294b4b6ad1b32eef6b7dcc8ad7071bbfb86d2e04de3b9386a26bacedc0cf2f4902f229bbc67bb4a03eff9eeab4d7fa2",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.fa.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.threading.timer/4.3.0/runtime.any.system.threading.timer.4.3.0.nupkg",
-        "sha512": "c0a1fc3661b4e21f329f88a8d2cbf7152698427778add9f850476fc9abe7cdf9b86df79362d6df025f7e15d53f5eb7937d8ac49bdef13fd9eca973a284929fcf",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.any.system.threading.timer.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.fi-fi/2.14.1/humanizer.core.fi-fi.2.14.1.nupkg",
+        "sha512": "f320d2b318de501b59e08065a48ec2ea1fbd3ad88d254d977070fa166ab9f97494217a060cbeb727f95f1470bbc519224af648fdf8a436728af25595ab92a8eb",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.fi-fi.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.text.encoding.extensions/4.3.0/runtime.any.system.text.encoding.extensions.4.3.0.nupkg",
-        "sha512": "656aa8bd9d7e19534964ac7b8405615f00359779e322d4cfe1f18c132fec4a4f52c5588bfe61cec9966a9142a73315f5d2b9e5a7c524b418364f0322b20961c3",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.any.system.text.encoding.extensions.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.fr-be/2.14.1/humanizer.core.fr-be.2.14.1.nupkg",
+        "sha512": "02d1ec8e702331865439371e6731d97cb5cd5f9816ee7fc4eeee4e896a23b6481a82a336e99c39898f8881323e6b85fd7710bf4b4b7e828fea5eba49dc3fc5e4",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.fr-be.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.resources.resourcemanager/4.3.0/runtime.any.system.resources.resourcemanager.4.3.0.nupkg",
-        "sha512": "39fab03cbade2b3848d62e137313530c06b37216e24cd58c70ed6ae54bdaf9d9613a3b410375ee167c87ff935a558b1f8766ee016b8b244fde99c38fcf42a49b",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.any.system.resources.resourcemanager.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.fr/2.14.1/humanizer.core.fr.2.14.1.nupkg",
+        "sha512": "096cfa2a0f4f5449e6bf381f4ca9e9f23acd94cb4d7e1ac79c7fc954e6189c16f478712327263538ca31599fd771634eec1be8386cce4a32432f1b8e2f28b629",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.fr.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.reflection.extensions/4.3.0/runtime.any.system.reflection.extensions.4.3.0.nupkg",
-        "sha512": "8de7a4c53fc0324e766bfec360342ee4a4b99a5975a9d61faab0a715ef71ff97aa83383a5a8affb354c02a4e2fbbb91e1b4ae6b282d2880108cb489f06aba500",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.any.system.reflection.extensions.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.he/2.14.1/humanizer.core.he.2.14.1.nupkg",
+        "sha512": "b8ca8bdf86220d2da24928b03365c67e316607f5efa3a6195ce6615a3c1881db0ce5fcf96dc6e99962e922ab6b0ebc5a734fb3536c0ba0477e82f6e47cff6396",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.he.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.threading.tasks/4.3.0/runtime.any.system.threading.tasks.4.3.0.nupkg",
-        "sha512": "5f37a56f5d6c7fc198c7ef76b822b85284f9d7d1c06583c26a698793ade65da1b273d5fb03c20be1eb91a9c835f7122ad2775f4e51dffb2758fabac2a30f8c23",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.any.system.threading.tasks.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.hr/2.14.1/humanizer.core.hr.2.14.1.nupkg",
+        "sha512": "a83c8f85ae2d7d456986b8023ec297479106640d4ddf442dcdd80775d9561d232e7ddb76713d6e7821d17a24e8fe32458baa7a198b610dc96cca1214cd47f35a",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.hr.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.diagnostics.tracing/4.3.0/runtime.any.system.diagnostics.tracing.4.3.0.nupkg",
-        "sha512": "0b480d21e23c38965222be7fa1e1a0c7e444cebdf400d1db8d3ac609f893b82d78c5d8b271da61808b7b179dd6466a0090bd807fc2d35020f93a00f0213bb436",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.any.system.diagnostics.tracing.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.hu/2.14.1/humanizer.core.hu.2.14.1.nupkg",
+        "sha512": "be3d3b194f163d81834405f3b5ffff4e7a55f8497f1a5e92b92d8e86ae01e5a78876c2e71370b81cb7c8e6301e5f26e59455ac79766373e087f7ebf17d5e44c4",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.hu.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/octokit/0.36.0/octokit.0.36.0.nupkg",
-        "sha512": "3826592bc1e7e0d86650a47c24e01bd28bd69ee921b3718a9d234c408dbdd0e2abc77f8b4d84e239d505f921def18fd2cf9e79babc1bea9d852f75c8be754c5e",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "octokit.0.36.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.hy/2.14.1/humanizer.core.hy.2.14.1.nupkg",
+        "sha512": "6ef922df2fd94b29a813808fbe678837931b5ce3fea35ed8ce41b4a10863bf9c1ca348867ed1da6b9cfe62443f3951777091a1a4734b714473faf67a812e2a73",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.hy.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.runtime.interopservices/4.3.0/runtime.any.system.runtime.interopservices.4.3.0.nupkg",
-        "sha512": "70eeb2469726d092bb95568e51ba5cfdd1cc07a9e65077e2b6dd5b7c8b164d4b45c749ef4a52f45928f63a27e8accdb83b861ea73c9ad3d42dc38e6afdbd0e8c",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.any.system.runtime.interopservices.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.id/2.14.1/humanizer.core.id.2.14.1.nupkg",
+        "sha512": "66eab78ad07fae2196aa1454e08c5541330cf7bbecda93a359288b125e0a7b83e5b47622c10709a243d2e5c045945ad7be79315b0c8f88988093270ad2a98096",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.id.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/messagebox.avalonia/0.9.0/messagebox.avalonia.0.9.0.nupkg",
-        "sha512": "525dca6cdc9d444242e72760261fb939da7becc9d9d659ef176bb473ae108c094ec4afec8e318848c5e4fd00624015a6b510153224c83ea0d4be0bd810b21f9e",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "messagebox.avalonia.0.9.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.is/2.14.1/humanizer.core.is.2.14.1.nupkg",
+        "sha512": "8b12be32e0b267926fa3ccaef2ff67f2bfc423d285913481e9bf82bfa00cbb819c7225478d14fac3c63e255440d3904d7a4112f39e460173d36d3e857139fe31",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.is.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog/2.9.0/serilog.2.9.0.nupkg",
-        "sha512": "2ba6a22fd294d611ce62b365bf1149a5ed218e6c74747e9730c90aa25c2089014eafd67290355f1a0a2305fd4afa5a6c5090f0ce7f3a228543a5ae40aaceec8e",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "serilog.2.9.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.it/2.14.1/humanizer.core.it.2.14.1.nupkg",
+        "sha512": "2cb65a6a6a775df3c61babb972ad9619dd74324b01ebdf94292c501cd620ccd653a705b0fdaba4917d4bbea3c05bd416f737f0815355c71916964d749a5a56eb",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.it.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.appcontext/4.1.0/system.appcontext.4.1.0.nupkg",
-        "sha512": "f724af13eb14aa57255f82841683a93b427de172b8d31b9fe2c6bc8c21a795e60ecf211b4e49e1c2e285fe1ad498e6bd9c843e109a60a3dc27b49df560106e96",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.appcontext.4.1.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.ja/2.14.1/humanizer.core.ja.2.14.1.nupkg",
+        "sha512": "9cef8d54342e93d2c4bfbe2e2eb1ddb31300d13686b45685eac17f5ed8ef165b0de8676173fedf0cb736fdf6d9c9eda83362cf3e8462ecab72e99217678910f2",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.ja.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.appcontext/4.3.0/system.appcontext.4.3.0.nupkg",
-        "sha512": "0d6ea63006304708feae2cc0590d2cdd99327b682210822bb2803ac842fdf4d8d57170d7947c006eec4b5687c942768478a7ec109745472f3946d230732483e8",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.appcontext.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.ko-kr/2.14.1/humanizer.core.ko-kr.2.14.1.nupkg",
+        "sha512": "bb5233e2467a79cd65832c7bf01a7fc65fd858c6ab0fe8802a46d514cd9b9a34c8a9eb94094ebfd153621d41b2956287d5911a68c67462548b13ba9178e44462",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.ko-kr.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.principal/4.0.1/system.security.principal.4.0.1.nupkg",
-        "sha512": "92b8b4c8b10c54f3d79c849b2169a1d012efd2151e5a864d6b1f0babec7ae4e96467f992cbdab922cbdc1f74539f222d1b3ee6725a6c4a5073cb1b3e27305d0e",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.security.principal.4.0.1.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.ku/2.14.1/humanizer.core.ku.2.14.1.nupkg",
+        "sha512": "da07569d4c1fe545b96393872bb172944ccf736ba5f88568478aec567f273af0207071e1f922d39b3e2f1fb92fc84ad28a9f276c9f3797b06282558e69180aee",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.ku.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.principal/4.3.0/system.security.principal.4.3.0.nupkg",
-        "sha512": "db8a1ed0d189637d9ef83147550ce5da890cf6ec189a7d006ba9de86ab55679e7f025e18bdaed2dc137ddf82a7e6a0131fb4d54d4264831862b1d7c5ee62837e",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.security.principal.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.lv/2.14.1/humanizer.core.lv.2.14.1.nupkg",
+        "sha512": "b976ed021bf47255a5c303bdb085c80ff8f2f08feb3b509c3be11e3844f4fa38bd12cee0da6a28e94a551b3b1014c98570794f3189acbcbe4fb2eb476e9b9066",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.lv.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.diagnostics.debug/4.3.0/runtime.unix.system.diagnostics.debug.4.3.0.nupkg",
-        "sha512": "a8ce331953b1f4424aa7f4b6dfedfce9ad138940bc92f332de2bc6d05185830ec6eb832e752f62eaf425f749caadd4ea1789121cb7ed79740fa5868eba55c838",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.unix.system.diagnostics.debug.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.ms-my/2.14.1/humanizer.core.ms-my.2.14.1.nupkg",
+        "sha512": "e4478cc1e689effd66520d889cd779b16c3898d1acd557cb62c9f4d293a389be34608e68778e1b72a45994497f9b04b4bbb635be1132b19949fe2969f36a788c",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.ms-my.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.runtime/4.3.0/runtime.any.system.runtime.4.3.0.nupkg",
-        "sha512": "bfee3c68312296860e5459af5e770c2e9fcd4ac134361fd569a9ce1e6574b9ae3978aad403f89639a4b5bac8ee5bb0ee1b8edb819e9a60f13ca5bd1812889bbd",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.any.system.runtime.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.mt/2.14.1/humanizer.core.mt.2.14.1.nupkg",
+        "sha512": "fb7bfdda10a5893c22dbe37545a9fd6d734730502d3e22b3226259eb183f7d47fd62a043b9bc606cf3cdbd21df166ac38447f4b5980ecdeed287cfab54b5b36a",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.mt.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer/2.7.9/humanizer.2.7.9.nupkg",
-        "sha512": "ea1f4eefe232c9bc2947b64a813fcee1f57bc979093a18fcb539f4f65b96d5a4e7548503cfa67edaabd1601c1218bf82f31a128113a32da58900e4dfbb135a72",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.2.7.9.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.nb-no/2.14.1/humanizer.core.nb-no.2.14.1.nupkg",
+        "sha512": "d3ff3f34ff9f8a8b1636e0867239d424064fdcabf262e69ccae2b6e9f31bd6d6eddb1c8c5e9e50ad2d72a308421152859355f88bad558d38f05f6dfbc6030e15",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.nb-no.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.claims/4.0.1/system.security.claims.4.0.1.nupkg",
-        "sha512": "45e4bc0836dfc76089f9ed5949c69a04e35b67d073f0ad43605387af94397be28affcfca591d10f6407d02133577d12a9ed0a8ee227f27962b6665c82afbdea7",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.security.claims.4.0.1.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.nb/2.14.1/humanizer.core.nb.2.14.1.nupkg",
+        "sha512": "1853a6e51ad295e68266851b5f492875ec54ec46d0ac23003bcaa456c74d1354ac508998c4e4cd404adf9e599ce62ec835ced390c2d31b277e1f5522a232ecb4",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.nb.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.claims/4.3.0/system.security.claims.4.3.0.nupkg",
-        "sha512": "ab72b90801f6c051a2b31645448eebfca74642b3cfa1d51f80e21a0d0d7ad44d3366dea139347e2852781b7f3bae820df16c3eb188a2c96244df05394ed72c86",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.security.claims.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.nl/2.14.1/humanizer.core.nl.2.14.1.nupkg",
+        "sha512": "39da68d62ef7e0f0fc2629c6d05186c1a181b3fb310b1b8a924b1a4ffe272a4fadfdd09d011d7d0f01a4012a5bc01aa2479f3d4ec3201d6f523d33ee48d6b429",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.nl.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.runtime.extensions/4.3.0/runtime.unix.system.runtime.extensions.4.3.0.nupkg",
-        "sha512": "54b81784c08e934389c59e6e155af6b1855e4bbc41678b01a702c94e6daba87c6ddfd16fe9e2cb61f3097bfa4950dbc37781454d027ce5ba6c50a393cc91b888",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.unix.system.runtime.extensions.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.pl/2.14.1/humanizer.core.pl.2.14.1.nupkg",
+        "sha512": "e645f2a540f9faad73b0441db3803c6d1f79c2df291dadf96bcc039708d7f765e1cfc52794c7eae53db52d0595d5f597f7ce246d8dddb377bdbad6754dff8d02",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.pl.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/12.0.3/newtonsoft.json.12.0.3.nupkg",
-        "sha512": "6934665f0479c58bbe996c44f2bf16d435a72f4d92795f0bc1d40cb0bc1358ff0e660ac20b24eabce01ee6145bd553506178e59fbaabd0f2a94b23bfa5c735f5",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "newtonsoft.json.12.0.3.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.pt/2.14.1/humanizer.core.pt.2.14.1.nupkg",
+        "sha512": "44939399ff726aa3dd09014b5664a64018dac533fcee01d2d00f625f7588d51f6651e565275a8c4783054ce6e00f20a84cb7838bef5be17d1a18aeafaf2a2577",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.pt.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/autofac/5.0.0/autofac.5.0.0.nupkg",
-        "sha512": "64404fce33b1977c2f246950217daf0ac471b542d3bf820713693b5c221cb25e55c8563cb2d5d34c0857cff0ae951460b810f963071418acfe1a5ff2815a06ce",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "autofac.5.0.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.ro/2.14.1/humanizer.core.ro.2.14.1.nupkg",
+        "sha512": "24709147cc3ff951de6d70a2b6d1e23b5a833bd05cd82260053fa0175029c71c0fb7c9cb57b95d8c924af991ce8998502cfb3f4c5543505a9fa03c78ab3f90ef",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.ro.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.net.security/4.0.1/runtime.native.system.net.security.4.0.1.nupkg",
-        "sha512": "a67044668bce06b249169fb639102cf9b62e11015c3b689804d6cdc110aacd9f54ed5bbaeaaa1325a7a4bce1a00b22a6b25bdc7af0152f19fbfcaf5773a97097",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.native.system.net.security.4.0.1.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.ru/2.14.1/humanizer.core.ru.2.14.1.nupkg",
+        "sha512": "af6304b2a2307a7c773af3a5b82e5053a61ac7e15d1852ef4d578f3215df7aaa4c430c3f3c8ca7da778e86682b0eba443a23f8e6942ca5c20120c2e5807f0b99",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.ru.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/mono.posix.netstandard/1.0.0/mono.posix.netstandard.1.0.0.nupkg",
-        "sha512": "46d1a2bad41924099a8ef43442f06f87bdd52727bce625bd7fdb63665cc5f3c89d2f134ca3894092d3ffe18f62942a5a8acd0b0ced2da68202b7d1ddbfac28a0",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "mono.posix.netstandard.1.0.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.sk/2.14.1/humanizer.core.sk.2.14.1.nupkg",
+        "sha512": "9a9c1210e52aa630820ca890993fe451501f436e65b7406d332e4711b92d43d31c0ed2f0c3fa26dd07b3191e992aeb34175c1c83cd880012f1504efe22b22f91",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.sk.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.principal.windows/4.0.0/system.security.principal.windows.4.0.0.nupkg",
-        "sha512": "55c673485e9274db630b40c41ba5de3f477671220ac9a79b0230cd1a5cf6fa51062b7cc47d98908ed412de363f2fc73cbc030c1f064c5d4ab743a82d106c532a",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.security.principal.windows.4.0.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.sl/2.14.1/humanizer.core.sl.2.14.1.nupkg",
+        "sha512": "6bc6554487df8e00d3a98e98137ceaae34b22c6b05c7556b7cf57b31b582aab58fdfb89cdc971f3083f156cb0994f7b3a5fc3bfd7f3b45fdf86242e871b2a2e5",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.sl.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.principal.windows/4.3.0/system.security.principal.windows.4.3.0.nupkg",
-        "sha512": "66c1d5a9d649b964e1653fa2cd41d8f80515b7cd727fcd7f0890552070da1099ecd1032560f259a108e0d1d6a6da23fa07bc5c922f426a91f33b667f7c004019",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.security.principal.windows.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.sr-latn/2.14.1/humanizer.core.sr-latn.2.14.1.nupkg",
+        "sha512": "1d68e4d6517e677a2c6214d4d8aad8aecc1f421bd6b6d213289144dd63bc5ddd25721035e9ddad7a1a2cfec95d2e16ef9a0a745e2881424c1b7c2a9082855918",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.sr-latn.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.principal.windows/4.5.0/system.security.principal.windows.4.5.0.nupkg",
-        "sha512": "86cdb3178b4e437578890b6d5672eb9d1fe2f003abac082ed869a9e3f8cd684ffee618995838f6d052bf9bf396dc8b5d8bd5c3bea7f9e56cc7922598b4e49436",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.security.principal.windows.4.5.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.sr/2.14.1/humanizer.core.sr.2.14.1.nupkg",
+        "sha512": "d2bbec20fad2f039cad9159c9c6b9fe577a49285458318356dfd773caf75e3305da3222a7303eb7a5f00abdd802c23602e76cbae8199ec9ee2a6a40c83e42afa",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.sr.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.primitives/4.0.11/system.net.primitives.4.0.11.nupkg",
-        "sha512": "50d5a977a4926fbfaf47bc4656111ed6edb8bb6acfff0cc5c2ee9c104628a255c8298a649f33ca2abdf9c7dacf4bfbf15e48ab7f92bd797b7d50ca328fac48b9",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.net.primitives.4.0.11.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.sv/2.14.1/humanizer.core.sv.2.14.1.nupkg",
+        "sha512": "224b73defd9e85b845ffce7b1423cb9167dc35cba476ffc70729aac2c5e13730a7daf55a2cc978c1a49fa3511372f181d04f16af7c6d1814fd3fb2d82d3e35c6",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.sv.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.primitives/4.3.0/system.net.primitives.4.3.0.nupkg",
-        "sha512": "9f7fdece330a81f3312ea7c804927852413bee2c929f3066b736993803df47cc0692fbca236c222bf19dc8f59b42f54f2a4c00da9a4d624e458da5874d127ce6",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.net.primitives.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.th-th/2.14.1/humanizer.core.th-th.2.14.1.nupkg",
+        "sha512": "cb30028a11380c53e595b15a567d3ffc5450a05f1b3d80e7d1744a5c28e631f616ed28e0752867a8dba763b0c0f58d1557956ce225055c008012d48a5b0332b2",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.th-th.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.microsoft.win32.primitives/4.3.0/runtime.unix.microsoft.win32.primitives.4.3.0.nupkg",
-        "sha512": "93e6d3db61f9c2ca2048f25990dda92acd5ec74561e0c776d2c6dd8d1d55128f2c953f33d6832fb6a72bd9edca304a2551085bdeafe6e18af87619c9ba943c32",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.unix.microsoft.win32.primitives.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.tr/2.14.1/humanizer.core.tr.2.14.1.nupkg",
+        "sha512": "bae26af2cb26d092bfeda8e47cf5caf69b5b0ce1ec76a2e0cbd11d500fd0e455a35d9fd38f95f7c780f48bb13a7eb51d65303529131612171e14e1e82bfd314e",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.tr.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.console/4.3.0/runtime.unix.system.console.4.3.0.nupkg",
-        "sha512": "7c5cbda7d12315fff6b1e036d55ea27140de8b849f1a9705fd2710a00a2b70f06f534eb0d3e3c8ffb019e1a47d96c559ac61d5fc9d840e48f6e56542fdaccb83",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.unix.system.console.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.uk/2.14.1/humanizer.core.uk.2.14.1.nupkg",
+        "sha512": "c17aed51857057f87535ac293da2ecc43a829ac6d0f3001e8759a655318e4753eaf6ab4876b4e1118845133453121d0ead34d56087d26ac262fe4c993c9b3d2f",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.uk.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.io.filesystem/4.3.0/runtime.unix.system.io.filesystem.4.3.0.nupkg",
-        "sha512": "6d4c80aceffac60e1560fda34c5984bbfa2e1bd106bde2c6d3540905cc30c58e6f5f2eaf5703cef5e68e3d25a4b97982193b2db8130a50c622a498e43eb9bdca",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.unix.system.io.filesystem.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.uz-cyrl-uz/2.14.1/humanizer.core.uz-cyrl-uz.2.14.1.nupkg",
+        "sha512": "d22e2a725fbc278968c3f24159f6850c441d480b48613bc333f89f357392376bc7c677faa11b669a9ee511dbd86db122033b4c3c55152f497a324b6d05a84354",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.uz-cyrl-uz.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.net.sockets/4.3.0/runtime.unix.system.net.sockets.4.3.0.nupkg",
-        "sha512": "31b62be088315ead04d89f452a6c49a656b88f0668f7dadb2790511675d48705e01c9df24dbed3a0095157875c208ab6e6b5b6afc82bac13e4d6cdd3026f8424",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.unix.system.net.sockets.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.uz-latn-uz/2.14.1/humanizer.core.uz-latn-uz.2.14.1.nupkg",
+        "sha512": "ac7258cc516fd2142e39ee623b6ada7197632170623de74d0ac665caa363359b72d31d42cb4f1a2981d57ea755d43133df49bebf0e2103f22ea516333310f6cb",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.uz-latn-uz.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/firebaseauthentication.net/3.4.0/firebaseauthentication.net.3.4.0.nupkg",
-        "sha512": "dd76352e02d64063912a6710cc00d053690b424005e11df26f92bb16310ab3340ca519c1ece6595578744a93047cc1a7888087205afb4eb5abe50f1bbdf81228",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "firebaseauthentication.net.3.4.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.vi/2.14.1/humanizer.core.vi.2.14.1.nupkg",
+        "sha512": "c2e0fc75d97458507b92f89a6201959eb1e00362268e670deef8ae4a801475e6b937c8af3f802e0c70b00923eef86d2a4870fb2a8061f0a3ae22ea8d85d89c7b",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.vi.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/autofacserilogintegration/2.1.0/autofacserilogintegration.2.1.0.nupkg",
-        "sha512": "429abe0b8e8e135cbfbee6f0d1d35d2edc80835936b056afc95d07f096e214c89f88083ba8d8b5642a46a824787b94715f371cb993af1619bd3f624e487e1984",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "autofacserilogintegration.2.1.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.zh-cn/2.14.1/humanizer.core.zh-cn.2.14.1.nupkg",
+        "sha512": "a978a46501a32a4f6944061cc9107415d2bb5131511e375a65603ebe99eb9e4ddc20b0c9bdcc95d15a41c0852af5034089d970da162532fb3e9e0db0f0864f44",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.zh-cn.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.collections/4.3.0/runtime.any.system.collections.4.3.0.nupkg",
-        "sha512": "9f8833176c139b71a58694ae401c5aec209a63227be07c7ab559bef772082bd1f6cc38ba2949cb1c8e5c5514ad9f4ff51859838dc2f28191f8bb7ae611a50239",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.any.system.collections.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.zh-hans/2.14.1/humanizer.core.zh-hans.2.14.1.nupkg",
+        "sha512": "8c96ee6d1d8663c89584af657b9a827297b2097d78803e0ae1a368b8d90827ab8c4975c7c1dafd2d5abd4fbeaed36ba18d19eb42ffc12205a382f2cfda4c901d",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.zh-hans.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.net.primitives/4.3.0/runtime.unix.system.net.primitives.4.3.0.nupkg",
-        "sha512": "c2a0ecf5c72b226b4776eb6281f00267827d6086a0ad758ebf6e6c64a1c148d2056fe99c87ab4207add5fa67f1db73dd1ed3dca81141fc896be6b6e98795c97e",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.unix.system.net.primitives.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.zh-hant/2.14.1/humanizer.core.zh-hant.2.14.1.nupkg",
+        "sha512": "2041d5d1f9bc550256a5a117b9b119a7b37a2d0013a00025f77fe1a7de4e5cfcd8465be0035286156279902db47d0eb05d41a910bcebd657fa8464760180a4c2",
+        "dest": "nuget-sources",
+        "dest-filename": "humanizer.core.zh-hant.2.14.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/reactiveproperty/6.1.3/reactiveproperty.6.1.3.nupkg",
-        "sha512": "5da1712d1941bc5d5f85f724411f102681a0edc57545c39f534f950eed495aa3c31ecea594995d612bfe5d51367f64b84b9b2ea64d5362fbdea5eb4544c5ecbd",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "reactiveproperty.6.1.3.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/jetbrains.annotations/10.3.0/jetbrains.annotations.10.3.0.nupkg",
+        "sha512": "ad0c0fdda8d66adbb5da6c83b562df9c45b1cb7ec146c892747cbfdcf4409b1e9d620840378cceb2a94889d7e4d3cd4318347b736eca97e801e59d2dcfb78afc",
+        "dest": "nuget-sources",
+        "dest-filename": "jetbrains.annotations.10.3.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.console/3.1.1/serilog.sinks.console.3.1.1.nupkg",
-        "sha512": "7c8d1fc4afdd715d3261d02a76b2781164bb0274b2be5c83355d07919177d8060d1eeed35ca9e637a410c85262c021d9169ea0864b15021c21fad1eca651c314",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "serilog.sinks.console.3.1.1.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/markdown.avalonia/0.10.11/markdown.avalonia.0.10.11.nupkg",
+        "sha512": "00d000f275b327ef2d1d1ad45193054c5042560aa5a8b56cc1d09ad357087b2f28c36c463bc6ae74901d2a70867502330db48867b61db0c230a687ee04a226d4",
+        "dest": "nuget-sources",
+        "dest-filename": "markdown.avalonia.0.10.11.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.emit.lightweight/4.0.1/system.reflection.emit.lightweight.4.0.1.nupkg",
-        "sha512": "542863fa085a31705b0b294b64744c11617a098beae4d5664beb53189148d19246c9a112de30f2d597e0888069a414f2aed8e94a2b369294a81b24b991bc2149",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.reflection.emit.lightweight.4.0.1.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/markdown.avalonia.syntaxhigh/0.10.11/markdown.avalonia.syntaxhigh.0.10.11.nupkg",
+        "sha512": "ce89a99f0ca2bb9069994da2a32e8789256cba60f7b078ac33cf7f398685a114ef61c0c03698da53d7c953a7d2bca29a2a506982193241949ad577b7f23a449a",
+        "dest": "nuget-sources",
+        "dest-filename": "markdown.avalonia.syntaxhigh.0.10.11.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.emit.lightweight/4.3.0/system.reflection.emit.lightweight.4.3.0.nupkg",
-        "sha512": "ad58af07296bd084907a089f92026fa3898b764eb9d6a07c9414b550a83ac60456f32a34127c29bb93a9633fb07ba9fd828f7b41a31dce5ff019a7cf1ab29435",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.reflection.emit.lightweight.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/markdown.avalonia.tight/0.10.11/markdown.avalonia.tight.0.10.11.nupkg",
+        "sha512": "953dc650af20a96b9297e4775361f4d91cbf90793c94c916458deaf9c4e24eea1fc53a8c9892ac7aed9d28708ecc508076f25bbd739c86db93271b121fb9db83",
+        "dest": "nuget-sources",
+        "dest-filename": "markdown.avalonia.tight.0.10.11.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.reactiveui/0.9.2/avalonia.reactiveui.0.9.2.nupkg",
-        "sha512": "074f418f5d4fac0c42bf3d3c654a5386d84174cd30b63fbbbbc9740b9858e309bdbd09b77718679bb44204746f70ba4b68c4579234a010ccf5501f698fa05e77",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "avalonia.reactiveui.0.9.2.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/messagebox.avalonia/2.1.0/messagebox.avalonia.2.1.0.nupkg",
+        "sha512": "349137e5e3500b1994202284b7dbbecaed0b573e66d0f59164ef03b51654b5537d1e21a82a3c6a2d5fd95b30abd6921ec5a24ccbb82da6609cf20d474fed6564",
+        "dest": "nuget-sources",
+        "dest-filename": "messagebox.avalonia.2.1.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia/0.9.2/avalonia.0.9.2.nupkg",
-        "sha512": "c39963d916ad0306072f6bb0baf2e6d6a6c5b60dc5eed5951dc0a3019c03b7d6d7a821c646f732cea7cd09be53f3e002d18f4bcd5bbb3f51940d7766533ad2a7",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "avalonia.0.9.2.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.analyzers/2.9.6/microsoft.codeanalysis.analyzers.2.9.6.nupkg",
+        "sha512": "30b2d92add884d8bdc62a40605dd314b7ce9c80a23ae64962b6745b35c302a3868d237be4b27a292cacbd1b80cc6ecfb1cb444108c07750eff8f400fe3e13470",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.codeanalysis.analyzers.2.9.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.overlapped/4.0.1/system.threading.overlapped.4.0.1.nupkg",
-        "sha512": "e74b5cc0dd9e446d3509bdeaf6f9717f447b1909d9c88e1ce2e5e9ad5135dc9a6fd4883098c6c0c165ae9e8e0404afb630f9b0651a493ffa6a2cc31a14c8289d",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.threading.overlapped.4.0.1.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.common/3.4.0/microsoft.codeanalysis.common.3.4.0.nupkg",
+        "sha512": "652914ddc4c651c6c68265636c3c4bc76b9207b745387e57345db4d9c44b6346a6a267550db9c153cd2f3fc248bd4a69ee55b4da8a0e07285b09324792e466e5",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.codeanalysis.common.3.4.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.file/4.1.0/serilog.sinks.file.4.1.0.nupkg",
-        "sha512": "d8da0003a49cfa3eec45315bbf58e8488be89840fae45ab59fdecadc9d1b7747c329f79b79e9be7909c101063d2e13825b3c560b04af44a008af87a4b0508001",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "serilog.sinks.file.4.1.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.csharp/3.4.0/microsoft.codeanalysis.csharp.3.4.0.nupkg",
+        "sha512": "271ec0ee5949771958cd05b63bf2a879f97abcfe8275bb36a40ad22e4a700614115517820eaae752f05fe24c338efa06d8ae3f667b04c91c1db8d9be8a9749e1",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.codeanalysis.csharp.3.4.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/nulastudio.netcorebeauty/1.2.3/nulastudio.netcorebeauty.1.2.3.nupkg",
-        "sha512": "3138ff75f09fb4a7771877c2b884a8bfb38356237547a5f62419d522ce67a10d3df345fbc5bf16cbad5ef11ae6a6b5904e148c3ded4f4d8ecfad2fb778ddd065",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "nulastudio.netcorebeauty.1.2.3.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.csharp.scripting/3.4.0/microsoft.codeanalysis.csharp.scripting.3.4.0.nupkg",
+        "sha512": "c3ea6676face82f86a2ca46224f668e5516a233e5229cf4ed75f7172612ed675ae87e1ee3eb10fd7568dd641721a302b140ee6867c2bc9a102339400ba80340f",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.codeanalysis.csharp.scripting.3.4.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.desktop/0.9.2/avalonia.desktop.0.9.2.nupkg",
-        "sha512": "4015d7b9e4dc663faccffd4e6e5da82b8a6fe8c5722b0b41617a0954b5f168cc0fc850839e0b3114302689de1deabcfdc0a63a3a5ef28e944e8bb007491f204f",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "avalonia.desktop.0.9.2.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.scripting.common/3.4.0/microsoft.codeanalysis.scripting.common.3.4.0.nupkg",
+        "sha512": "ad40179f4516a236ca01f65c4762d0420fff5738177dea5506eb5d66e0f431e52cf0e36a0777c4db8f5748e69ea506e54fb0dc0a5f0e28af2e7e6968020c73f5",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.codeanalysis.scripting.common.3.4.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system/4.3.0/runtime.native.system.4.3.0.nupkg",
-        "sha512": "299c5a96fffdcaf1972e3e3d1c727837d18ac9e88cb79c09914f12ff1de7280dff10c9232a49a1c1d3ba7785a5cf76f28c9dce414f0a2a567688de7fd5331dc8",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.native.system.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.csharp/4.3.0/microsoft.csharp.4.3.0.nupkg",
+        "sha512": "30c440b34652c8af000557a50286b75579dd5311bf5b9da24e8e572f46a311a747cd46b7e0279607010f34e2c5ee8393041b536366c0770aea8a97c101e2d91a",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.csharp.4.3.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system/4.0.0/runtime.native.system.4.0.0.nupkg",
-        "sha512": "55ff3eafa406ec3d8e33d8be44d0d06352ce746abffdec1378716b275d634e133fc1bc56fc312bf0d921efc59e8de4ac811022cc34a77fc1f1abc982c931932b",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.native.system.4.0.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/1.0.1/microsoft.netcore.platforms.1.0.1.nupkg",
+        "sha512": "5f3622dafd8fe8f3406c7a7ee506a7363c9955b28819ae1f2b067c38eae7ab6e620eb63442929b967c94fc511e47a2b7547ab62b6f1aafe37daa222499c9bb19",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.netcore.platforms.1.0.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.private.uri/4.3.0/system.private.uri.4.3.0.nupkg",
-        "sha512": "5989a57ef273b689a663e961a0fe09d9b1d88438e5478358efc4b165de3b2674fa9579c301ce12d2d2fa5f33295f2acb42eceea2ebebf70c733da6364ceaf94d",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.private.uri.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/1.1.0/microsoft.netcore.platforms.1.1.0.nupkg",
+        "sha512": "6bf892c274596fe2c7164e3d8503b24e187f64d0b7bec6d9b05eb95f04086fceb7a85ea6b2685d42dc465c52f6f0e6f636c0b3fddac48f6f0125dfd83e92d106",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.netcore.platforms.1.1.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.fr-be/2.7.9/humanizer.core.fr-be.2.7.9.nupkg",
-        "sha512": "698a561d2e6df070f03cb4c00bfd9648ec76ecdf9e056c12e2beb76eab7dec521265e10882533af6f874e453f6ef22b1e047f930cedee79d874252b8614e37d7",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.fr-be.2.7.9.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/1.1.1/microsoft.netcore.platforms.1.1.1.nupkg",
+        "sha512": "9835090f578b5c8ce6527582cd69663506460e9fdc5464fc2b287331c24d9369e57dd1543a865a8bd89d4fcfc569c26bf0dbfcce102675fdfd1479b9a9652819",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.netcore.platforms.1.1.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.nb/2.7.9/humanizer.core.nb.2.7.9.nupkg",
-        "sha512": "3dfbb5aa5aa09305530a295595b4d85f51d046904ce18ac7974e6f30704a0d9f8beb62acb9066dfd07edc50b304c2f89f2aa243d266905b7f692325a2d4116de",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.nb.2.7.9.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/2.0.0/microsoft.netcore.platforms.2.0.0.nupkg",
+        "sha512": "0827f83639833a88ac7bb1408a3d953ee1c880a2acbbaf7abe44f084e90f5507cbb13981d962c57d0e3278ee5476d93c143eb7e9404cc7a63d7a8bf324a4fbe8",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.netcore.platforms.2.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.bg/2.7.9/humanizer.core.bg.2.7.9.nupkg",
-        "sha512": "aff595891449634725ab16ac2dbed66d0572ff4d5053ae5fcb997ac8d6f364152543d23ca03838c343ab0fbca40cef1b7c19b85fb523229d5eaf439eb0a0cb5f",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.bg.2.7.9.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/2.1.2/microsoft.netcore.platforms.2.1.2.nupkg",
+        "sha512": "ec9eef7881fb32eeb37389655a733b611813bfdf84c3e2569240e3d0aedc11ef30b8503a1d1b7a493b70bb1da0faa8e90d7798796b0ad14437b8881189360722",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.netcore.platforms.2.1.2.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.af/2.7.9/humanizer.core.af.2.7.9.nupkg",
-        "sha512": "eff9a8400ad29b8175ec9844560ed9faf7aa054434a9e34c1c46739471c3c2757dc96514d6a5efd1a22ca6936847ab8d7cb1f9412c12d3417dda7f9ddb0e4ae7",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.af.2.7.9.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.targets/1.0.1/microsoft.netcore.targets.1.0.1.nupkg",
+        "sha512": "6ed8e75f945a18651066fe9ee31cf6c8257a5974340fe4d262438903c4959a479f4a515a4d1389e6d3d3ab34f09a3c7bc2009aada2e8a7f697b6655a82d3bfc9",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.netcore.targets.1.0.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.bn-bd/2.7.9/humanizer.core.bn-bd.2.7.9.nupkg",
-        "sha512": "8ecdfe1d4f6e9cc7cad734cbb17caa3018b0d0c3560a50aba793c6ddbd71230d11da18c36beedb00341360e53ec7ef35e49b92aded37c13803363db495bae7c1",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.bn-bd.2.7.9.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.targets/1.1.0/microsoft.netcore.targets.1.1.0.nupkg",
+        "sha512": "1ef033a68688aab9997ec1c0378acb1638b4afb618e533fcaf749d93389737ba94f4a0a94481becdf701c7e988ae2fe390136a8eae225887ee60db45063490fe",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.netcore.targets.1.1.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.cs/2.7.9/humanizer.core.cs.2.7.9.nupkg",
-        "sha512": "797ac0daf0bbde8369b6cde61067486cabb92461ae40d8b9f23f135d92e7dfb49d42bfaac10acc3b0bf6466feb8eb4c00ca8b1ea3e74d34ff4b9ce7f15214d2b",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.cs.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.da/2.7.9/humanizer.core.da.2.7.9.nupkg",
-        "sha512": "d11df853ab0fcb5cbe54d6dd7ee589492fe5657a6e4f5b246db34dcb2d171f68debc2339c944d8981c880fb74c883f416b09b233635a334ab60b05876dff7f02",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.da.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.de/2.7.9/humanizer.core.de.2.7.9.nupkg",
-        "sha512": "b1d9c5013048de69252d497d29c49d856debb8db203acc57626f5414d6f7ba6036796ce67f41c2a124fbc292cdd35f9f1fa17233bfd50c04f5193aa3fae0e613",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.de.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.el/2.7.9/humanizer.core.el.2.7.9.nupkg",
-        "sha512": "428ae73ab38f6bc952dbe96b64966a988a920210296517782b90259b7a9493a1c56cfaf91918de8e327de2a4a70ae330f064d109c84988943091c51243d78ba2",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.el.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.es/2.7.9/humanizer.core.es.2.7.9.nupkg",
-        "sha512": "ba95f2f2456b77aa5e654ee926c219096c318791b7b192a0c450003362bf36d40dc713d0799dace085913d8b0240b3c61aa425e8bf9b7be1a883729223268835",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.es.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.fa/2.7.9/humanizer.core.fa.2.7.9.nupkg",
-        "sha512": "add6a4a6b068ccbbe6a71e96b4324dfe947db9e41d3ad86237610744a776dfbc1f393523b995c66501e35b918f8588bf4a01d759ee23fc3d671496f9d1cb54cd",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.fa.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.fi-fi/2.7.9/humanizer.core.fi-fi.2.7.9.nupkg",
-        "sha512": "42210a37f0df8b167142ca55ab857725ddf49a96ceb40abfdd62179f636d380d3ab8c46302d0d388f7ea1467766a72e40a73c2fc952ba719b59db31cdd8a5fbe",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.fi-fi.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.fr/2.7.9/humanizer.core.fr.2.7.9.nupkg",
-        "sha512": "223915be1836a13082062a9380d5179293d814992b2741f0b78cc05d72c2a6c156d06000507b8ed4def8e8ebf769b7b90abe62c499a00c2ee587de029fd96449",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.fr.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.he/2.7.9/humanizer.core.he.2.7.9.nupkg",
-        "sha512": "6ba2337675cb070cda8cb98df3bdeafac6095cbed33b5086c878038db8dee51d182e9093f606278a9ab95a20ed899f8b9773e916eb1cb7d35e9c83da87563125",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.he.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.it/2.7.9/humanizer.core.it.2.7.9.nupkg",
-        "sha512": "959b9ef4a63ce116ebd63895e4ac7ef284edab3bb3e2047512948a967194249dda818573ff2485fd98a717963c266c86fb97e2155027c450f7a9737767d6f0ec",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.it.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.ja/2.7.9/humanizer.core.ja.2.7.9.nupkg",
-        "sha512": "06d5707a023f8ce4acb769442021ea261b34a13894d61d492af743b9a840d178b0a04937cb8a5a65624a5f1afc8b465c7ebc8ca2f9e016adc5cce425befd225e",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.ja.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.lv/2.7.9/humanizer.core.lv.2.7.9.nupkg",
-        "sha512": "85ae81c8aacea6260c811777a0726c2fbed69c3101df87fc6188aba7d023cd8ba5176cbbefd366f56fdc46e243cea72eba0c38597e976c04efed2672db7c934d",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.lv.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.ms-my/2.7.9/humanizer.core.ms-my.2.7.9.nupkg",
-        "sha512": "953292baecc2842780f7e579c9bce7481eb8b2bdb63d19e5985f81dc2977c6ceaa3f044995d4d0697d93169abe37e20a7c756a304234f853a68a9b6aedc4af02",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.ms-my.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.mt/2.7.9/humanizer.core.mt.2.7.9.nupkg",
-        "sha512": "5bdf15d3cb692ae1f4e14f3f2af2aaf4059818fc502c587bf7c99d687b6c0a439f944ca8d9ea8fbe200955f119545ffce8dc5d140876dc0b4f24b8f6c6d26383",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.mt.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.pl/2.7.9/humanizer.core.pl.2.7.9.nupkg",
-        "sha512": "7fe036046867261a98d38db7476605d5f2f323ab2da35e36876b85517ffb98c6fa852510378d789547a3cc3ddb389eccf402d15b17191663965bfc26ebc1b48a",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.pl.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.pt/2.7.9/humanizer.core.pt.2.7.9.nupkg",
-        "sha512": "2a4a661750d3624a56fa976b5576446a7608fc2968b591a28637f6307ecba2ea8ede6c8b8309b1225f0d7774e83fa691d80fb77010479dca833445690dd356b8",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.pt.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.ro/2.7.9/humanizer.core.ro.2.7.9.nupkg",
-        "sha512": "54d86d1dbdabad01ffc8f303a0f957d0309b48a8bda97182830690b28322327b7686cd0faed3f26ba61581ade8db57ee09dc24b59e7f4aa86edaa9b95c64a76e",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.ro.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.ru/2.7.9/humanizer.core.ru.2.7.9.nupkg",
-        "sha512": "c1a196809cf9711c1620b5e4730ad2e7e28d6cbbdf5485e1b01b7da141d9af9dc42f965d39a70b531fa34a36caddbe407eecef07f3e56cf1ae197dc2b1930def",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.ru.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.tr/2.7.9/humanizer.core.tr.2.7.9.nupkg",
-        "sha512": "dc186248cbc53875bcaf473ccfbf51485b570372c3942e197e805376156b03e7814c4fb796956d4d33d2a57e0739f3eeca4608c79ea6ea39185b027a3945373c",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.tr.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.uz-cyrl-uz/2.7.9/humanizer.core.uz-cyrl-uz.2.7.9.nupkg",
-        "sha512": "1c1f1f3efc018b217ac5fa03bf3d4c37aebbdeb9b216a6049a7690a22665a6cee9f1cd6903626be68a37671b28d47b02dd9e3aea69fa3d417945da2aeff894c8",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.uz-cyrl-uz.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.zh-hant/2.7.9/humanizer.core.zh-hant.2.7.9.nupkg",
-        "sha512": "ec3dc320bd1a2185c2fe694244ee3e781b0d0b621493b8b1c6238551cbcc881cd83bcbaecc9459e2570ca91966aba319bfc85e935e96fe70ff9948c09e35e73d",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.zh-hant.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.ar/2.7.9/humanizer.core.ar.2.7.9.nupkg",
-        "sha512": "59933e365115deb189195988c96195d136294dcb05a2cab45fcc690e3bd1d42e5fe92404f918406edc3b6774425bf1ef8519609df58abf40e58846c10ed96318",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.ar.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.sk/2.7.9/humanizer.core.sk.2.7.9.nupkg",
-        "sha512": "42e04dff201a7d9d0d4dd4e3e06d3bd04f9414060900363cc764d160e4255c0325557844f20c2360a6e46aba9c26f916ba7fb1bdd8b4ec9fc42e206ececc3bcc",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.sk.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.sr-latn/2.7.9/humanizer.core.sr-latn.2.7.9.nupkg",
-        "sha512": "3f7d087f004cace5a67f9b92a2899648a1b0d51afda64ffe0d4c110e08c12874bf24dc61ba9e21e111aca9bac3a785d146b547888a75a3e562470ac06a07d390",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.sr-latn.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.nl/2.7.9/humanizer.core.nl.2.7.9.nupkg",
-        "sha512": "6f82c3a938acf3b4a284df147100dd1817f6b80a99d0cf61c0d6f505ff3464bbb5e8553408e3beff09015c39c8759915750a62b3b19c675ec5cc34f3580a3693",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.nl.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.sr/2.7.9/humanizer.core.sr.2.7.9.nupkg",
-        "sha512": "d63cbd85fbe5f0d6a814c0cd494fba1a8d178b25290dea5bc315dbf9571852e98fcef17b3165337e6b5ddd23c373285161e08380d66788fe2ff195018743600b",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.sr.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.sv/2.7.9/humanizer.core.sv.2.7.9.nupkg",
-        "sha512": "1b5b5089c133bce9cfd1b7b3b38aa6dd97af793cd0fa480da6794f6fcef1b4def7fc04845ed01aa7e3ca1f40ae1679fe5a0d56a64e1665ed258e398b10ae94d9",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.sv.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.registry/4.0.0/microsoft.win32.registry.4.0.0.nupkg",
-        "sha512": "5224a9ee54f11adb05e89f7ac3012b15e3348f2823fdb5962af6eac2d44fdade8ea21813ed3093a63bd0d7eec32d02c7dc347bd22ebe791197ff2f39585bb3d5",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.win32.registry.4.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.hu/2.7.9/humanizer.core.hu.2.7.9.nupkg",
-        "sha512": "616f59eafa4bad6770dc2a8b149014b403cc6878b1a4813180a9069561656915e14f831e4f6bb477c8e8e047efdc65ca53e5d020752dc7739292530ca89dd54e",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.hu.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.nb-no/2.7.9/humanizer.core.nb-no.2.7.9.nupkg",
-        "sha512": "e6cd85ed054035de406b85c7b9c1e8ea222024e79c72345dfc8ccfb6303e490e61461261681f501c118bf04f88e0d6ea1ff203e42cb837b3c5764a8adbef58aa",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.nb-no.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.hr/2.7.9/humanizer.core.hr.2.7.9.nupkg",
-        "sha512": "7db2621448942f941bbba2154f6d4d1e24e2106ef57b69ceb736482b83efc43b4f1c14d21be6445555f2761a962263bb6e4a29a39a0c801421adf815e69e38bf",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.hr.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.vi/2.7.9/humanizer.core.vi.2.7.9.nupkg",
-        "sha512": "882d32b7c99e4f8bab531d878398fd768683cad8b7f00e74117527271eed5377010effb199a7afcdb3af983321310bd408404a6e413eb4e212bce44b73e33ad6",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.vi.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.primitives/4.0.1/microsoft.win32.primitives.4.0.1.nupkg",
-        "sha512": "382bd3a66349e077fdf622a69a2d9e2a07d15143cf238f4fa21c74f2c1e5592f8ba97e6fb956c1c69ca0cf4eba91ca4a7d3c8ef195289c5a0e95bcac52e794be",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.win32.primitives.4.0.1.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.targets/1.1.3/microsoft.netcore.targets.1.1.3.nupkg",
+        "sha512": "a71c2af20d8f61188417929756399914c353aac8361abd69baffe9475b2a01db802870066da0ae27afb2737a4026c782950503dbd4b651bae6ee7fd90fbf1d52",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.netcore.targets.1.1.3.nupkg"
     },
     {
         "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.primitives/4.3.0/microsoft.win32.primitives.4.3.0.nupkg",
         "sha512": "366f07a79d72f6d61c2b7c43eaa938dd68dfb6b83599d1f6e02089b136fa82bec74b6d54d6e03e08a3c612d51c5596e3535cbc2b29f39b97a827b3e7c79826f0",
-        "dest": "LocalNugetPackages",
+        "dest": "nuget-sources",
         "dest-filename": "microsoft.win32.primitives.4.3.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.id/2.7.9/humanizer.core.id.2.7.9.nupkg",
-        "sha512": "5455d0e0073cceec786096ed902c6af2ff3c2c5fcd40419c24a6680b9589deb3d8caf722a853be3a37c78dd56410dc2bac7df1ff2c300f357a85f2e10b0c9ec2",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.id.2.7.9.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.systemevents/4.5.0/microsoft.win32.systemevents.4.5.0.nupkg",
+        "sha512": "2b64c0af4ee9825fe6fc9f5e777726033c74483e79918b957c11ba48f4481ff10b4e1fc3daa1ab8ce583409a3bafe2d99759ced8d925d14010054b7a4b67b0a9",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.win32.systemevents.4.5.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.uz-latn-uz/2.7.9/humanizer.core.uz-latn-uz.2.7.9.nupkg",
-        "sha512": "9a50204b17cb6e55e93efad0e38852d222a607280e467e9df73e7c66b95dc9953939d3f6e40f228a86d8e31f6a0b58f4d571ba6890b5f90855d31f1026952f99",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.uz-latn-uz.2.7.9.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/mono.posix.netstandard/1.0.0/mono.posix.netstandard.1.0.0.nupkg",
+        "sha512": "46d1a2bad41924099a8ef43442f06f87bdd52727bce625bd7fdb63665cc5f3c89d2f134ca3894092d3ffe18f62942a5a8acd0b0ced2da68202b7d1ddbfac28a0",
+        "dest": "nuget-sources",
+        "dest-filename": "mono.posix.netstandard.1.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.uk/2.7.9/humanizer.core.uk.2.7.9.nupkg",
-        "sha512": "3be91b68fcc5bd1d8cd6d53a76a810c6d96b388a74f488a336cf87805e23f990f44386b9f051c8f5650ea3cee4a0df630b9b40bcea098451c0e6fc042567ffd7",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.uk.2.7.9.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/morelinq/3.3.2/morelinq.3.3.2.nupkg",
+        "sha512": "15a97158c7ec83cf909aa4acc5e40f58344e1bceb4da93ea35c0bde9182be176f4d7198617438fbe73d63e5ede99dd46b84c069fbc461891e5b38339b607f2c6",
+        "dest": "nuget-sources",
+        "dest-filename": "morelinq.3.3.2.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.zh-hans/2.7.9/humanizer.core.zh-hans.2.7.9.nupkg",
-        "sha512": "88a2d10ada5a8ef9c86890791b94efedaf20754f9109db573f60287875b2762a7b958f76e5665d86d3fb25b81a09491543cbabcabaf16bb0ca4a2e049fef1950",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.zh-hans.2.7.9.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/netstandard.library/1.6.1/netstandard.library.1.6.1.nupkg",
+        "sha512": "0972dc2dbb4925e896f62bce2e59d4e48639320ee38ad3016dcd485fbd6936a0ed08073ad5eef2a612dff05dfc390f3930fff9e79d87a06070eeb8128277cbd0",
+        "dest": "nuget-sources",
+        "dest-filename": "netstandard.library.1.6.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.zh-cn/2.7.9/humanizer.core.zh-cn.2.7.9.nupkg",
-        "sha512": "5187a7cc6215599bcf2517982a3f780133648357721709a88f2e59620044e434efc21ef457a38dd9f7a43806907811fdec357ca0612db9928f186db21e3e8f93",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.zh-cn.2.7.9.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.2/newtonsoft.json.13.0.2.nupkg",
+        "sha512": "d743ae673bac17fdbf53c05983dba2ffdb99d7e6af8cf5fe008d57aa30b6c6ca615d672c4140eec516e529eb6ad5acf29c20b5cc059c86f98c80865652acdde1",
+        "dest": "nuget-sources",
+        "dest-filename": "newtonsoft.json.13.0.2.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core.sl/2.7.9/humanizer.core.sl.2.7.9.nupkg",
-        "sha512": "0f79c14b3babf74bc59a040af5a307b84b07be61d9ad01071d4ac4c2e1b2c3afc46f3d811d093a6d42cb97a0c13f5c29234137f05cc8ba1fea1c53fd61b8e401",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.sl.2.7.9.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/nulastudio.netcorebeauty/1.2.9.3/nulastudio.netcorebeauty.1.2.9.3.nupkg",
+        "sha512": "3358d5e2663a2fe6826564367e801a7b7beb6437dea77167a9127a31b8632cc9e3cd47a9d7e909259ca2e758975f3c1d1b7c5207c18a74c2aa4ab43b1d484d3c",
+        "dest": "nuget-sources",
+        "dest-filename": "nulastudio.netcorebeauty.1.2.9.3.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/octokit/4.0.3/octokit.4.0.3.nupkg",
+        "sha512": "25a30be3808c1c585d82fc4cb1cccef5b911870f4080f3a131012305ddf64d2759e9a5a2b6e80706bbf17963c19c6ad9771887cd634dafbf9eba688352026faf",
+        "dest": "nuget-sources",
+        "dest-filename": "octokit.4.0.3.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/reactiveproperty/8.2.0/reactiveproperty.8.2.0.nupkg",
+        "sha512": "49cc4094cc32515c2400e9c8336daf2f496cffb594432b0883366f1e686dac0f5740ca6be49fa0a15d72f1fc2c35ad6520fd797af1d1dabb4370a3408965f007",
+        "dest": "nuget-sources",
+        "dest-filename": "reactiveproperty.8.2.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/reactiveproperty.core/8.2.0/reactiveproperty.core.8.2.0.nupkg",
+        "sha512": "2aec389665d889f60039e26d90046d9b188c93b2b87f9e1f9a4642f99c6c51eeacb0d2d71068f7c59a3da76bc06f4678d63f266e26328928a567441ad9d959a9",
+        "dest": "nuget-sources",
+        "dest-filename": "reactiveproperty.core.8.2.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/reactiveui/13.2.10/reactiveui.13.2.10.nupkg",
+        "sha512": "ab57ffbebb378fa74fcd46171c573c2fffd94bc581af809f99d0e1df60b3840efb8addd22fe77d3cb382c4199c0fa708e2563ebb0c79311391f7aa80df103790",
+        "dest": "nuget-sources",
+        "dest-filename": "reactiveui.13.2.10.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.collections/4.3.0/runtime.any.system.collections.4.3.0.nupkg",
+        "sha512": "9f8833176c139b71a58694ae401c5aec209a63227be07c7ab559bef772082bd1f6cc38ba2949cb1c8e5c5514ad9f4ff51859838dc2f28191f8bb7ae611a50239",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.collections.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.diagnostics.tools/4.3.0/runtime.any.system.diagnostics.tools.4.3.0.nupkg",
+        "sha512": "bd257401e179d4b836a4a2f7236a0e303ae997d2453c946bf272036620a0b14e85e5f42c229332930a954655ab4cae359d191a3e3d9746df09535a651367764c",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.diagnostics.tools.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.diagnostics.tracing/4.3.0/runtime.any.system.diagnostics.tracing.4.3.0.nupkg",
+        "sha512": "0b480d21e23c38965222be7fa1e1a0c7e444cebdf400d1db8d3ac609f893b82d78c5d8b271da61808b7b179dd6466a0090bd807fc2d35020f93a00f0213bb436",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.diagnostics.tracing.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.globalization/4.3.0/runtime.any.system.globalization.4.3.0.nupkg",
+        "sha512": "3aac1a076212fae7d0ac81d2b5fdf216b064a1d890577307f89c9a4984c239838c3bdfac4dea052027de090704839319231eef49ce542f3e8bb2f85ba23d28dc",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.globalization.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.globalization.calendars/4.3.0/runtime.any.system.globalization.calendars.4.3.0.nupkg",
+        "sha512": "19053b502b7160af6f6b0bc5b334a8d124f77f6b4418993294fb485d0bb318cd6e97cdbda9bf8c9927366288413cad7209c9d8156a5425a6320c453a8804fb3d",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.globalization.calendars.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.io/4.3.0/runtime.any.system.io.4.3.0.nupkg",
+        "sha512": "7e0d4a238322d434a19afc79ea988d3727c1687fdd5bcd1c4c39cb6201073caabb924cc201c70545d60acf8b94cde8b783d0c268743e040c357d100677e4c5ed",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.io.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.reflection/4.3.0/runtime.any.system.reflection.4.3.0.nupkg",
+        "sha512": "293d3dd8be87e1c5cd76ece4ed64ebb5ae6b50be95a39bee401eeed64355e34641905f8c14392fbc3acf8609f5d6fca731f39ce7607962eb5951f09516480015",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.reflection.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.reflection.extensions/4.3.0/runtime.any.system.reflection.extensions.4.3.0.nupkg",
+        "sha512": "8de7a4c53fc0324e766bfec360342ee4a4b99a5975a9d61faab0a715ef71ff97aa83383a5a8affb354c02a4e2fbbb91e1b4ae6b282d2880108cb489f06aba500",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.reflection.extensions.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.reflection.primitives/4.3.0/runtime.any.system.reflection.primitives.4.3.0.nupkg",
+        "sha512": "a2f374276290ad9b799d3e49cd8fe7839c07b52f22894bcd77b9470841564319fb2ebbd7503e76feef42db4e8a362af8648cf0842a1cb0b5d9a60a58ef8b205e",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.reflection.primitives.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.resources.resourcemanager/4.3.0/runtime.any.system.resources.resourcemanager.4.3.0.nupkg",
+        "sha512": "39fab03cbade2b3848d62e137313530c06b37216e24cd58c70ed6ae54bdaf9d9613a3b410375ee167c87ff935a558b1f8766ee016b8b244fde99c38fcf42a49b",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.resources.resourcemanager.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.runtime/4.3.1/runtime.any.system.runtime.4.3.1.nupkg",
+        "sha512": "c505b72209cfe3fd78d428af757194cd7c281bab7a76ddebd31ff08455bb7fdaaa6a9d18bc5d49d315e634b333cbe70c877aca433e012d1513d2cf9eee9601d4",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.runtime.4.3.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.runtime.handles/4.3.0/runtime.any.system.runtime.handles.4.3.0.nupkg",
+        "sha512": "95cdae2867a2182535bd0f4d01dc3eff70319dff044b070ab7791fa2bf8688a69b00a279ed569b7f0c5f3e26bf705303dc344ecf7d1ea014c579436d8e7b7389",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.runtime.handles.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.runtime.interopservices/4.3.0/runtime.any.system.runtime.interopservices.4.3.0.nupkg",
+        "sha512": "70eeb2469726d092bb95568e51ba5cfdd1cc07a9e65077e2b6dd5b7c8b164d4b45c749ef4a52f45928f63a27e8accdb83b861ea73c9ad3d42dc38e6afdbd0e8c",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.runtime.interopservices.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.text.encoding/4.3.0/runtime.any.system.text.encoding.4.3.0.nupkg",
+        "sha512": "cbe6df98acd50e2251d3343620c408af56cfe7c1979277a8ec65b5eef093e93ed93c05980902a7152ed83302d5a625d7058921baa7f446c5e67194fa4c06f20a",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.text.encoding.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.text.encoding.extensions/4.3.0/runtime.any.system.text.encoding.extensions.4.3.0.nupkg",
+        "sha512": "656aa8bd9d7e19534964ac7b8405615f00359779e322d4cfe1f18c132fec4a4f52c5588bfe61cec9966a9142a73315f5d2b9e5a7c524b418364f0322b20961c3",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.text.encoding.extensions.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.threading.tasks/4.3.0/runtime.any.system.threading.tasks.4.3.0.nupkg",
+        "sha512": "5f37a56f5d6c7fc198c7ef76b822b85284f9d7d1c06583c26a698793ade65da1b273d5fb03c20be1eb91a9c835f7122ad2775f4e51dffb2758fabac2a30f8c23",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.threading.tasks.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.threading.timer/4.3.0/runtime.any.system.threading.timer.4.3.0.nupkg",
+        "sha512": "c0a1fc3661b4e21f329f88a8d2cbf7152698427778add9f850476fc9abe7cdf9b86df79362d6df025f7e15d53f5eb7937d8ac49bdef13fd9eca973a284929fcf",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.threading.timer.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
+        "sha512": "b2cf809fe50c4b46bd6f2372265cd3059622550123afceb5dbb2410906c07a7f47bae4273584d29253d5e7a63a17c68c7ba0434608bbc8fd4d00e479b2f128ff",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "8f071552ee042f0cba39b1ba0a1205cf73de447d662995bae68f857a5946f7d154c029a79e37469081675687873c8bf2b9efe57f5cbd660c366b1ca51823f7f2",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
+        "sha512": "fd8e32d7d3e9a465202e391b0ab8b95e212900879bc4d8ac22954fd2d0f98fa579e9d25f88885ac2a4bf1eba755db940f8d131250a3ffec34dbe77431a379cab",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "a135ca0f4f5a49319b5a52b7f4338f8a5fc4387edf26f29e6cbf63a3c3a37b2b5c51c9caf562ec41e470fba281060362465bc56915be782d6c75778aa6195e46",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
+        "sha512": "4afac5cc1734330a6103880e790d639e825bfb1b34dbd42083762c47db5e5dab6c03efd16049ac03861d7d87746caed09c7534241d51b7341d47ba6af7e8dd31",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "2f24e2cba88a96bb23848e1404878e4478a65642387b7b76aa4007587fe7c4d8208cbde53d3ed65f8d0d71cd688bfc16be66dc5f7bcf84c7b2ccf1b3c505b0b4",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system/4.3.0/runtime.native.system.4.3.0.nupkg",
+        "sha512": "299c5a96fffdcaf1972e3e3d1c727837d18ac9e88cb79c09914f12ff1de7280dff10c9232a49a1c1d3ba7785a5cf76f28c9dce414f0a2a567688de7fd5331dc8",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.native.system.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.io.compression/4.3.0/runtime.native.system.io.compression.4.3.0.nupkg",
+        "sha512": "bff1f0cac94327014bb07c1ebee06c216e6e4951b1ddaa0c8a753a4a0338be621fd15ec621503490dbca54a75809abc4f420669b33052b28d24d726ac79c9891",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.native.system.io.compression.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.net.http/4.3.0/runtime.native.system.net.http.4.3.0.nupkg",
+        "sha512": "ddd1e5b67545477f7c72b5883666de40e89efb0836d91e7a349e2f3d4ac05ce1125e6add3cb09c39cbdfe7ab7c5dc8fdaeaf6ac25acd92f6de3d8ce2d6db7918",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.native.system.net.http.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.security.cryptography.apple/4.3.0/runtime.native.system.security.cryptography.apple.4.3.0.nupkg",
+        "sha512": "23c6a99b323cd71cdcb28c6faa71f099f69ff0972d5125607ae8bbc99ba7c08513571d14526e8c2805ab3a8b70d3d3a6dd76dfa193320393ecb05906ee91f37d",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.native.system.security.cryptography.apple.4.3.0.nupkg"
     },
     {
         "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.security.cryptography.openssl/4.3.0/runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
         "sha512": "ee5d047908b99b776ff9bb54856454b24b09a0f9271b127239543b1f5faa3381a032d9eeb4d813d01b5a4b7d183b6a16250f159fdc450d5314a7eace1550bea3",
-        "dest": "LocalNugetPackages",
+        "dest": "nuget-sources",
         "dest-filename": "runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.interopservices/4.3.0/system.runtime.interopservices.4.3.0.nupkg",
-        "sha512": "650799c3e654efbb9ad67157c9c60ce46f288a81597be37ce2a0bf5d4835044065ef3f65b997328cbbbbfb81f4c89b8d7e7d61380880019deee6eb3f963f70d9",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.runtime.interopservices.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.security.cryptography.openssl/4.3.2/runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "a34ad2dbe67efcae97fcbea57af386b30660a98ab8229a56c0dca241316e673cf7a26e19c6efb6b7117cc271fdf208741ba6f8447ae254c91acba3ddb7d2923a",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.interopservices/4.1.0/system.runtime.interopservices.4.1.0.nupkg",
-        "sha512": "e8511e6a4cd40f3c603df4ffbbf6a4aac4d10be79bcfd0249a9af90d55cf2a02543ad9b82e607a4665d58f28c7ce9bdb0f7f3ff9bc8ded8a252213916a771bd2",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.runtime.interopservices.4.1.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
+        "sha512": "81bdb93c1c86c560343df6cc367499fb2a01a9b3016617be416874a23c4355a8d95c7be34f175510f3fdea4872302a87c8efab98a328dfa39422db520c3f291c",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime/4.3.0/system.runtime.4.3.0.nupkg",
-        "sha512": "92ab2249f08073cfafdc4cfbd7db36d651ad871b8d8ba961006982187de374bf4a30af93f15f73b05af343f7a70cbd484b04d646570587636ae72171eb0714fb",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.runtime.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "ce0873e07000df98e640bd265e969d4a9236535cee2699c5363f3ab297557b0d756260557995f2ee163cff05fc2ba922d66ba0e4cb28521f841e7d546ab3b63e",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime/4.1.0/system.runtime.4.1.0.nupkg",
-        "sha512": "4b05eb68bb485846707c4fe3393f9616d3ffb6c5f62a121d81142ddf7d0241c931fe96d193b7bf02281a9368458e0764466766557cfa9709035dc76d8fdd7706",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.runtime.4.1.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
+        "sha512": "6de9544b4da49f127680cf5b3b4afea96bfcac3293038a1b0a12eea0ad60be368af31ee1dfd66d48d458b40200738c04aa0c71adcc54ae2dddbea2cd50d6f28d",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "bf754c1a66cd70dc1bd38d54fe675e9dd470417ebba62e2f79e278be8f06cc3496ff58ed90d30b5dd4d3efea9accbd09eb17cd87be882951c0fdfb833c371f70",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple/4.3.0/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg",
+        "sha512": "9929942914071e0ea0944a952ff9ad3c296be39e719a2f4bb3eac298d41829b4468b332fba880ebe242871a02145e1c26dc7660021375d12c7efcae4d200278a",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
+        "sha512": "61da1667a5dd1e53a5d19fbe90abbfe332d84fe755fb811a080668a47d41a97db44539e3174fd1d2a0770ff1bd83afa68c82ce06df5775da65a6054ccc12c4be",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "0a38f25e8773b58155b5d3f94f849b93353d0809da56228b8ebab5c976e6458ca50eb5a38acca4c8940678e6e9521fb57ae487337f7cbf2ea7893ae9e3f43935",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
+        "sha512": "e65a6a1f1928cfb760c395a399542dc7f9087399c53874376604504ae60abd2da24ed735ebd148d335000a5e35c8108ea55404685e902df392eac2e8d38fb665",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "2ae9db4b719b31fa7e40c60f52c70038fc8668e029cf4e1d120fde8c295631d6b08207d7018a22937b79546016c560c894e27dd6ebc01d5e0f677567e6b2c4f2",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
+        "sha512": "c9f219515e268cf40e16b135bd64cba95c35e866dd9bc34954159562314d01d2f9ea7eb8b0db94acf6bdac83d651d90bad7890cb657ffe40fa3440ec662c9944",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "cd4b7ba744de80086521ab67cad2db3085d488388d3d9cb83d9946389f0f4c784539bf3a4ffb8d4f3347c5c7813aadef95b355fd2563e30c948a883c27b95287",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
+        "sha512": "4981b2d7a106703b185e176ad35bfda149156f3b752778fa71c56b3686407765fd2b6625de352bd563aac1e1e8769d7886cc59a0d5d0bfb41ed60277360beb81",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "d7fc28a9f600e471edce0989c01c485d4e2a7e99551f531413afa75039a4004d4e2c27e88976d65432635a321d86316a3c6cdaebc7b2fefa42141b64f4f10d66",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
+        "sha512": "5dbe6bc007a9b46491e5299602291f5dbf8cc8d51e6c1b08db2fa0efd365990b41b6e181ed6bf82e873a659396427bc0e33e85b47d645d273fef8bf8ec643631",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "5fe0e6a878eff59cfe24a8d57af51140576d8e0fec4988e4892c233c47b3a3eed27dec072a6c0d55dd615777cd9ce3fe545c5353b4a95289376ad0b9408ed4be",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.microsoft.win32.primitives/4.3.0/runtime.unix.microsoft.win32.primitives.4.3.0.nupkg",
+        "sha512": "93e6d3db61f9c2ca2048f25990dda92acd5ec74561e0c776d2c6dd8d1d55128f2c953f33d6832fb6a72bd9edca304a2551085bdeafe6e18af87619c9ba943c32",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.unix.microsoft.win32.primitives.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.console/4.3.1/runtime.unix.system.console.4.3.1.nupkg",
+        "sha512": "60f5797aecf53434fd422ea6ab60425bbd29f9779a9a12d7e50997d5330842dd970d3dcccd1a5e9668a1f2b3c8cd2f324e61d740f71e9310f8109a2baed6831a",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.unix.system.console.4.3.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.diagnostics.debug/4.3.0/runtime.unix.system.diagnostics.debug.4.3.0.nupkg",
+        "sha512": "a8ce331953b1f4424aa7f4b6dfedfce9ad138940bc92f332de2bc6d05185830ec6eb832e752f62eaf425f749caadd4ea1789121cb7ed79740fa5868eba55c838",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.unix.system.diagnostics.debug.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.io.filesystem/4.3.0/runtime.unix.system.io.filesystem.4.3.0.nupkg",
+        "sha512": "6d4c80aceffac60e1560fda34c5984bbfa2e1bd106bde2c6d3540905cc30c58e6f5f2eaf5703cef5e68e3d25a4b97982193b2db8130a50c622a498e43eb9bdca",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.unix.system.io.filesystem.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.net.primitives/4.3.1/runtime.unix.system.net.primitives.4.3.1.nupkg",
+        "sha512": "f652488e1605ebf3063d0dedb53ea1ab5a4135211bf6880eb600af63d95543236245c2a3796becd571525c3cddfee90e350ad5927b0e4fc786de56a51115514d",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.unix.system.net.primitives.4.3.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.net.sockets/4.3.0/runtime.unix.system.net.sockets.4.3.0.nupkg",
+        "sha512": "31b62be088315ead04d89f452a6c49a656b88f0668f7dadb2790511675d48705e01c9df24dbed3a0095157875c208ab6e6b5b6afc82bac13e4d6cdd3026f8424",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.unix.system.net.sockets.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.private.uri/4.3.2/runtime.unix.system.private.uri.4.3.2.nupkg",
+        "sha512": "35e1c405ab12e3a6cbba0dd74f2e9716732a03600be16ae5b88ec626dcc91857b65cd35e031be70dc55a7275010b1694a57c3baec87f464b7357be4200f7f4ed",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.unix.system.private.uri.4.3.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.runtime.extensions/4.3.1/runtime.unix.system.runtime.extensions.4.3.1.nupkg",
+        "sha512": "d2854307ba04f22f661576e143499773b5d9a2aaef57203dd76d12fc78378adce60a2343d9402c332aae0ca8d97385a49951e6dba5e4a891c2c298e8b5de9638",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.unix.system.runtime.extensions.4.3.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/serilog/2.12.0/serilog.2.12.0.nupkg",
+        "sha512": "3546b98340b8399a8ca778b9b82072833ade67b2a016fe261f5a93a3f9afda222a1f432b146dc06edddb68e6bd32bffa4a9aacaae03205c365b43f88044111fd",
+        "dest": "nuget-sources",
+        "dest-filename": "serilog.2.12.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.console/4.1.0/serilog.sinks.console.4.1.0.nupkg",
+        "sha512": "3ce2d33bf374074657f175402e07929b5952c1345ceedce8a6162b8fb98ab123a2b9ce9daa6fe2309ef1b5e59ff1f59ac60017b89fd89767276dcb00ea5573f3",
+        "dest": "nuget-sources",
+        "dest-filename": "serilog.sinks.console.4.1.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.file/5.0.0/serilog.sinks.file.5.0.0.nupkg",
+        "sha512": "e0139b1c37bbc6e8dcf4b44f696fae1212c7793a69d599d3a555f69d2ceaa92f2417a0d4d2845d80ea8be494d4fd994841b916b197f8dc597afb6a6d91528356",
+        "dest": "nuget-sources",
+        "dest-filename": "serilog.sinks.file.5.0.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp/2.88.1-preview.108/skiasharp.2.88.1-preview.108.nupkg",
+        "sha512": "4e283d7b377c8bc6bfd1295fe9e977169447b870a994102f7d24b08b176846a0ca7f01539d75b84c5a8d7a545cd627c838b8194e0c4cd1e5a868396acf1a3483",
+        "dest": "nuget-sources",
+        "dest-filename": "skiasharp.2.88.1-preview.108.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.linux/2.88.1-preview.108/skiasharp.nativeassets.linux.2.88.1-preview.108.nupkg",
+        "sha512": "e60ed0a574bb1d76057b1ec7c71d223a1e8c4d7722095979d9f3cef7706b8a084b302aeb5bb81c79f5daaf886ad48b229e0826388353abefd0b45487a18bb48b",
+        "dest": "nuget-sources",
+        "dest-filename": "skiasharp.nativeassets.linux.2.88.1-preview.108.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.macos/2.88.1-preview.108/skiasharp.nativeassets.macos.2.88.1-preview.108.nupkg",
+        "sha512": "0ba49dc28fca165f60a842ce7323b773b52847ff4c1af054a3da74892b7132246fe2dfdacc2527d044522712c20d8bdf4b158128d88f9b9156a677eb60375e5e",
+        "dest": "nuget-sources",
+        "dest-filename": "skiasharp.nativeassets.macos.2.88.1-preview.108.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.webassembly/2.88.1-preview.108/skiasharp.nativeassets.webassembly.2.88.1-preview.108.nupkg",
+        "sha512": "10adc0bb36530b690c784407524ef5f6298dbd5a21fc32beb7be0fd4004905e2d775bd1edde55b7efbfd6a97bbf7660175ed6ca7fbf1ae8ecea008fd8bb4bde7",
+        "dest": "nuget-sources",
+        "dest-filename": "skiasharp.nativeassets.webassembly.2.88.1-preview.108.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.win32/2.88.1-preview.108/skiasharp.nativeassets.win32.2.88.1-preview.108.nupkg",
+        "sha512": "46a101fb62e66a43c81bc69ee073ccaeab38e0ef764806f03b7812dbd6364dd1433752518a44d6adef100190b959a29462f5b60a258243d40994a25fc56b8607",
+        "dest": "nuget-sources",
+        "dest-filename": "skiasharp.nativeassets.win32.2.88.1-preview.108.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/splat/10.0.1/splat.10.0.1.nupkg",
+        "sha512": "ae2190512080e039ce395d9adc84100c94bb0f1aac4eee2c63b42afd013a3919199136376056f32f52852e32a20cbb36aab35352e2ce0faa0b72a983aad384ce",
+        "dest": "nuget-sources",
+        "dest-filename": "splat.10.0.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.appcontext/4.3.0/system.appcontext.4.3.0.nupkg",
+        "sha512": "0d6ea63006304708feae2cc0590d2cdd99327b682210822bb2803ac842fdf4d8d57170d7947c006eec4b5687c942768478a7ec109745472f3946d230732483e8",
+        "dest": "nuget-sources",
+        "dest-filename": "system.appcontext.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.buffers/4.3.0/system.buffers.4.3.0.nupkg",
+        "sha512": "3dcbf66f6edf7e9bb4f698cddcf81b9d059811d84e05c7ac618b2640efed642f089b0ef84c927c5f58feffe43bb96a6bcf4fec422529b82998b18d70e4648cbe",
+        "dest": "nuget-sources",
+        "dest-filename": "system.buffers.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.collections/4.3.0/system.collections.4.3.0.nupkg",
+        "sha512": "ca7b952d30da1487ca4e43aa522817b5ee26e7e10537062810112fc67a7512766c39d402f394bb0426d1108bbcf9bbb64e9ce1f5af736ef215a51a35e55f051b",
+        "dest": "nuget-sources",
+        "dest-filename": "system.collections.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.collections.concurrent/4.3.0/system.collections.concurrent.4.3.0.nupkg",
+        "sha512": "35c1aa3e636216fe5dc2ebeb504293e69ad6355d26e22453af060af94d8279faa93bdcfe127aecb0b316c7e7d9185bcac72e994984efdb7f2d8515f1f55cf682",
+        "dest": "nuget-sources",
+        "dest-filename": "system.collections.concurrent.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.collections.immutable/1.5.0/system.collections.immutable.1.5.0.nupkg",
+        "sha512": "4f95c64257078443bbe50c77f061825033dd9389ffef2ad1993832e32733cc957c6a53c76b13d4e794c10b6505ae4438d9bbb7e2c64f7cad1d53e9d665438424",
+        "dest": "nuget-sources",
+        "dest-filename": "system.collections.immutable.1.5.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.collections.immutable/1.6.0/system.collections.immutable.1.6.0.nupkg",
+        "sha512": "607f7fad70cc92fb5d22689ea24ad63f9616491a945d1c6020a4403051faf028ade09a017388b17322c3b46422fd9c22d11422d52f1c233f25afa093a6cc3cfa",
+        "dest": "nuget-sources",
+        "dest-filename": "system.collections.immutable.1.6.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.componentmodel.annotations/4.5.0/system.componentmodel.annotations.4.5.0.nupkg",
+        "sha512": "7f5029507196abf9490bc3d913b26a6c0ded898ed99e06503b699b61f086d0995055552aaa654c032d1f32f03012e1badfd338ec42dd3fa3d0c5ce4e228ea2e8",
+        "dest": "nuget-sources",
+        "dest-filename": "system.componentmodel.annotations.4.5.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.componentmodel.annotations/5.0.0/system.componentmodel.annotations.5.0.0.nupkg",
+        "sha512": "589aac4c669701ce7910f1a327294f15788d3ecff1d6df5d9255651e5201c5411c2312286fab111a6f549fb4de864c8414cfaf2a365deeb6f068c1ffce7c353c",
+        "dest": "nuget-sources",
+        "dest-filename": "system.componentmodel.annotations.5.0.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.console/4.3.0/system.console.4.3.0.nupkg",
+        "sha512": "a08a684a583c9b3278ce32be1007dae495f9d87254666392f794ef1203079f333cd7d388c28944ffa36fb49f0c8bb21f42c70f6e1d7c1c03920df6d0d1130c82",
+        "dest": "nuget-sources",
+        "dest-filename": "system.console.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.debug/4.3.0/system.diagnostics.debug.4.3.0.nupkg",
+        "sha512": "6c58fe1e3618e7f87684c1cea7efc7d3b19bd7df8d2535f9e27b62c52f441f11b67b21225d6bcd62f409e02c2a16231c4db19be33b8fab5b9b0a5c8660ddab24",
+        "dest": "nuget-sources",
+        "dest-filename": "system.diagnostics.debug.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.diagnosticsource/4.3.0/system.diagnostics.diagnosticsource.4.3.0.nupkg",
+        "sha512": "8f54df5ff382b6650e2e10d1043863a24bf49ff0714e779e837cd7073e46fb2635bcfcdcf99d7c4a9d95f35ebffd86ab0ca068305f4b245072e08303b917b34d",
+        "dest": "nuget-sources",
+        "dest-filename": "system.diagnostics.diagnosticsource.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.diagnosticsource/4.7.1/system.diagnostics.diagnosticsource.4.7.1.nupkg",
+        "sha512": "65fd7fda175481b603ad730e2ec2b7f67ff83b5145f9b92d3a54fcd7a692cea30f0eddd53a3126b98077989e460bc2faaf77cdf20bb6645bd4a25c44821bcbb0",
+        "dest": "nuget-sources",
+        "dest-filename": "system.diagnostics.diagnosticsource.4.7.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tools/4.3.0/system.diagnostics.tools.4.3.0.nupkg",
+        "sha512": "164d6977e721cbceb44ede7bfd75b03b8d9771e0426aefa5d40c71867e964092fdc6a6808bcbc5559ed73ec2c532ca657d6476af79a49ca3ad879b8366f13d90",
+        "dest": "nuget-sources",
+        "dest-filename": "system.diagnostics.tools.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tracing/4.3.0/system.diagnostics.tracing.4.3.0.nupkg",
+        "sha512": "d0a5d30e261cd45b7dfab02b7ffbd76b64e0c9b892ed826ea61481c983c0208b05b69981cd79e91cd4e5811e1cd4c3cea06a1afce05811ece58be5e4c20169ea",
+        "dest": "nuget-sources",
+        "dest-filename": "system.diagnostics.tracing.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.drawing.common/4.5.0/system.drawing.common.4.5.0.nupkg",
+        "sha512": "b988b161b074bf3c526dcf41ee3cf0c1403c529a1d6a3de0d99367444596eb3a01c3d0e5b7396d7046b5834238bba011a95274b78137c89016c3987682f26585",
+        "dest": "nuget-sources",
+        "dest-filename": "system.drawing.common.4.5.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.dynamic.runtime/4.3.0/system.dynamic.runtime.4.3.0.nupkg",
+        "sha512": "54446fee94f432cb8fd38ec10c929a87b307a76f152a2e9da11ba99c41ceb0f65913cf218944990f0e122d4f858945091e9806c84c0285ada1fcc939337d30ea",
+        "dest": "nuget-sources",
+        "dest-filename": "system.dynamic.runtime.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization/4.3.0/system.globalization.4.3.0.nupkg",
+        "sha512": "823d2ba308cb073b40a3146ecccd0d9fd7b1615ac3fbefb16f73d873e411fd81c3bdc87df206d3dc7e2f14c9cd53aafca684a3570c25471280aada8de805ece2",
+        "dest": "nuget-sources",
+        "dest-filename": "system.globalization.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization.calendars/4.3.0/system.globalization.calendars.4.3.0.nupkg",
+        "sha512": "e97190231402b393774b925efc02a2bfa41d1d117a17fb87da6e399f5234546962767e9cd8f39970efa408e4f453cd1e6751a2a61e366bc97406e1b0b8a4be86",
+        "dest": "nuget-sources",
+        "dest-filename": "system.globalization.calendars.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization.extensions/4.3.0/system.globalization.extensions.4.3.0.nupkg",
+        "sha512": "a4d360003f95e0c31edf39c0b91e1c73850a60ac5d0032b17db888a3c7d7134cef9acd97219d14174ad213b7c044f49b364cc5720073ebfcb6e1bf6e4ec24ce5",
+        "dest": "nuget-sources",
+        "dest-filename": "system.globalization.extensions.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.io/4.3.0/system.io.4.3.0.nupkg",
+        "sha512": "bfca5a21e3e1986b9765b13dc6fbcd6f8b89e4c1383855d1d7ef256bf1bf2f51889769db5365859dd7606fbf6454add4daeb3bab56994ffb98fd1d03fe8bc1e6",
+        "dest": "nuget-sources",
+        "dest-filename": "system.io.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.io.compression/4.3.0/system.io.compression.4.3.0.nupkg",
+        "sha512": "f540ee51a3bb6941cdfbaace9a9738d7f7986a2f94770db61f45a88ecb7ef36b571d4c07417dc89cdbe9655a262b7cc599b0a4b78effea91819e186121b44807",
+        "dest": "nuget-sources",
+        "dest-filename": "system.io.compression.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.io.compression.zipfile/4.3.0/system.io.compression.zipfile.4.3.0.nupkg",
+        "sha512": "1860634672767f818f0192ec2b2750693f0d39390f3b7d400cc6fd4f6e74a5cbed27bf49e5980ec85ff3e161c30f6190f700e339a1040c1699b87eb4aa7b6792",
+        "dest": "nuget-sources",
+        "dest-filename": "system.io.compression.zipfile.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.io.filesystem/4.3.0/system.io.filesystem.4.3.0.nupkg",
+        "sha512": "4fb581d6f85b9529a091a0e974633752aa39e50b2be6c8a9e5eca8c2bc225cea07064ccec7778f77df9987deebf4dccec050b1a97edac0ee9107142e6a8ee7ee",
+        "dest": "nuget-sources",
+        "dest-filename": "system.io.filesystem.4.3.0.nupkg"
     },
     {
         "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/system.io.filesystem.primitives/4.3.0/system.io.filesystem.primitives.4.3.0.nupkg",
         "sha512": "5885953d09582cffd973d23a21a929064d72f2bc9518af3732d671fffcc628a8b686f1d058a001ee6a114023b3e48b3fc0d0e4b22629a1c7f715e03795ee9ee5",
-        "dest": "LocalNugetPackages",
+        "dest": "nuget-sources",
         "dest-filename": "system.io.filesystem.primitives.4.3.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.filesystem.primitives/4.0.1/system.io.filesystem.primitives.4.0.1.nupkg",
-        "sha512": "dce1c4074938391ea4ea01226812982a893bfc910e66ac99ecfe31c9b6fe635f3fbff11dcab222ed5036eb21c4f49cd3f121c310adbf87d22cf3d512bf6a9d73",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.io.filesystem.primitives.4.0.1.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/system.linq/4.3.0/system.linq.4.3.0.nupkg",
+        "sha512": "eacc7fe1ec526f405f5ba0e671f616d0e5be9c1828d543a9e2f8c65df4099d6b2ea4a9fa2cdae4f34b170dc37142f60e267e137ca39f350281ed70d2dc620458",
+        "dest": "nuget-sources",
+        "dest-filename": "system.linq.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.linq.expressions/4.3.0/system.linq.expressions.4.3.0.nupkg",
+        "sha512": "61b90ef9ae6f779fbc8a7b6483ee8f5449cdd05c81b05235f70447e656a73b2aab7c341784b999f7532374744a72e2c3a5cd13800ea23417fac32ccfae5cde6d",
+        "dest": "nuget-sources",
+        "dest-filename": "system.linq.expressions.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.memory/4.5.3/system.memory.4.5.3.nupkg",
+        "sha512": "70fce15a52cc76aacbae05c8e89e2e398d1d32903f63f640a7dd4a3e5747f2c7a887d4bfd22f2a2e40274906cf91648dfd169734fb7c74eb9b4f72614084e1db",
+        "dest": "nuget-sources",
+        "dest-filename": "system.memory.4.5.3.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.net.http/4.3.0/system.net.http.4.3.0.nupkg",
+        "sha512": "e8105ce8151aee95852fb29423f73cc1bd7c2286d36474ed7102a4b31248e45f434434a176d3af0442738398c96c5753965ee0444fb9c97525abbd9c88b13e41",
+        "dest": "nuget-sources",
+        "dest-filename": "system.net.http.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.net.nameresolution/4.3.0/system.net.nameresolution.4.3.0.nupkg",
+        "sha512": "40d39e131fe7a392e58e9f58b516b5db88383de91c05b771f5e509acf46cc874271e90623d327ab039003ab8f2714144694390261278de324e1aee228a828ab4",
+        "dest": "nuget-sources",
+        "dest-filename": "system.net.nameresolution.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.net.primitives/4.3.0/system.net.primitives.4.3.0.nupkg",
+        "sha512": "9f7fdece330a81f3312ea7c804927852413bee2c929f3066b736993803df47cc0692fbca236c222bf19dc8f59b42f54f2a4c00da9a4d624e458da5874d127ce6",
+        "dest": "nuget-sources",
+        "dest-filename": "system.net.primitives.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.net.sockets/4.3.0/system.net.sockets.4.3.0.nupkg",
+        "sha512": "e32ed9518e9630e99edcf1963c3d0e7047ea8252853c9260eb5403a4206170ae28fd27eb239f39da4d2db766f830b3ebdc9e4da2e697be20241d928082200955",
+        "dest": "nuget-sources",
+        "dest-filename": "system.net.sockets.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.numerics.vectors/4.5.0/system.numerics.vectors.4.5.0.nupkg",
+        "sha512": "9c04ec0530f608aaf801837a791b33857e2ca6d2265a6049c01fd4e972825967e709cad3070f174829b7400f608e9a641d3afc3a45d4636d4c47dd43dd0657b3",
+        "dest": "nuget-sources",
+        "dest-filename": "system.numerics.vectors.4.5.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.objectmodel/4.3.0/system.objectmodel.4.3.0.nupkg",
+        "sha512": "409bca3d2139bd1d003c711400ba2db5e576bb54d593aa541ec3576e7b2029b60159ab1c5b2c4e7389267b1b95ebcd8c2f064dc6e1f53e693aacb1737f066123",
+        "dest": "nuget-sources",
+        "dest-filename": "system.objectmodel.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.private.uri/4.3.1/system.private.uri.4.3.1.nupkg",
+        "sha512": "5c8dcb4a7fbe8939d15e2bad3053d343e872706a9d0eef2cdafc5bcc7206b3675ae74ddeded679c72f08328a18e1bd23c0d85afd2f1412fed10b9d7fdd3f1004",
+        "dest": "nuget-sources",
+        "dest-filename": "system.private.uri.4.3.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.reactive/5.0.0/system.reactive.5.0.0.nupkg",
+        "sha512": "23156e017b081b88aba7d9462438e09024003c61874e9798d389841a0f215cab63bdc69ab25d0ad3f1bf75d65d76771810f9d0184c338fd96c0b5c1e21df9590",
+        "dest": "nuget-sources",
+        "dest-filename": "system.reactive.5.0.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection/4.3.0/system.reflection.4.3.0.nupkg",
+        "sha512": "2325b67ed60dce0302807064f25422cbe1b7fb275b539b44fba3c4a8ce4926f21d78529a5c34b31c03d80d110f7bace9af9589d457266beac014220057af8333",
+        "dest": "nuget-sources",
+        "dest-filename": "system.reflection.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.emit/4.3.0/system.reflection.emit.4.3.0.nupkg",
+        "sha512": "be45051467a36ab965410f112a475fb81510a5595347d1cc0c46b028e0436a339218dd3c073f048c2d338b67dc13b45742290b6c46f55982503f74a8f2698818",
+        "dest": "nuget-sources",
+        "dest-filename": "system.reflection.emit.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.emit/4.7.0/system.reflection.emit.4.7.0.nupkg",
+        "sha512": "10c0325b993a31d993c58adeee5f1c6fd7ff66173bf22bf0d295d29bfb30f0e01ec3042aceac5e245bb62d8fbfed63ce02adf74e04cf55811e0cf3d541b897a9",
+        "dest": "nuget-sources",
+        "dest-filename": "system.reflection.emit.4.7.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.emit.ilgeneration/4.3.0/system.reflection.emit.ilgeneration.4.3.0.nupkg",
+        "sha512": "e9be5f62bf64b1947a49857337306a5d0980686b58d665989e94006ab04aa7e0bbf4d8543d1b57d5bb38079052f275f339b73054a7357e4fa357208a0ac85d69",
+        "dest": "nuget-sources",
+        "dest-filename": "system.reflection.emit.ilgeneration.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.emit.lightweight/4.3.0/system.reflection.emit.lightweight.4.3.0.nupkg",
+        "sha512": "ad58af07296bd084907a089f92026fa3898b764eb9d6a07c9414b550a83ac60456f32a34127c29bb93a9633fb07ba9fd828f7b41a31dce5ff019a7cf1ab29435",
+        "dest": "nuget-sources",
+        "dest-filename": "system.reflection.emit.lightweight.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.extensions/4.3.0/system.reflection.extensions.4.3.0.nupkg",
+        "sha512": "06cfd992c8d7fd9ab6432ab02be981a01b6558285a6e26a7825a064d4efcce08d9e7344f03fa19b033a2459d42b0b80e8c1400ce39b47a1752869ab8825b0475",
+        "dest": "nuget-sources",
+        "dest-filename": "system.reflection.extensions.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.metadata/1.6.0/system.reflection.metadata.1.6.0.nupkg",
+        "sha512": "f5227666edc6bb1da78b8a8e86a68e9bd647caa2ec6a1580c14a4a5e1fe5cfde3bdaf0d8c23dc210c405a55f83ceb6add1a9adab149dc065b38cfddc9b01ba20",
+        "dest": "nuget-sources",
+        "dest-filename": "system.reflection.metadata.1.6.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.primitives/4.3.0/system.reflection.primitives.4.3.0.nupkg",
+        "sha512": "d4b9cc905f5a5cab900206338e889068bf66c18ee863a29d68eff3cde2ccca734112a2a851f2e2e5388a21ec28005fa19317c64d9b23923b05d6344be2e49eaa",
+        "dest": "nuget-sources",
+        "dest-filename": "system.reflection.primitives.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.typeextensions/4.3.0/system.reflection.typeextensions.4.3.0.nupkg",
+        "sha512": "68ae81a635b9af2aee9fc8fc8fe7da0356ef4da4eb32f81a89fb75613b96714e8f1a1f4c12bd0d335efbb03408cc7a744314837f13564d5fb262ca272055677f",
+        "dest": "nuget-sources",
+        "dest-filename": "system.reflection.typeextensions.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.resources.resourcemanager/4.3.0/system.resources.resourcemanager.4.3.0.nupkg",
+        "sha512": "9067db28f1c48d08fc52ad40a608f88c14ad9112646741ddaf426fdfe68bed61ab01954b179461e61d187371600c1e6e5c36c788993f5a105a64f5702a6b81d4",
+        "dest": "nuget-sources",
+        "dest-filename": "system.resources.resourcemanager.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime/4.1.0/system.runtime.4.1.0.nupkg",
+        "sha512": "4b05eb68bb485846707c4fe3393f9616d3ffb6c5f62a121d81142ddf7d0241c931fe96d193b7bf02281a9368458e0764466766557cfa9709035dc76d8fdd7706",
+        "dest": "nuget-sources",
+        "dest-filename": "system.runtime.4.1.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime/4.3.0/system.runtime.4.3.0.nupkg",
+        "sha512": "92ab2249f08073cfafdc4cfbd7db36d651ad871b8d8ba961006982187de374bf4a30af93f15f73b05af343f7a70cbd484b04d646570587636ae72171eb0714fb",
+        "dest": "nuget-sources",
+        "dest-filename": "system.runtime.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime/4.3.1/system.runtime.4.3.1.nupkg",
+        "sha512": "025ebd98f0dfcdd0fe6ca18ad8701f07e94d14e1c5aa792accd9d42669af51ed7fa843caf4cec48934f8ceec9c2833f2edebf5d71cfc5d580958a3f4866ecd20",
+        "dest": "nuget-sources",
+        "dest-filename": "system.runtime.4.3.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.5.2/system.runtime.compilerservices.unsafe.4.5.2.nupkg",
+        "sha512": "84c91d5b192cca942515707b25a9907a00ec73110040ee051ddfe5c3fce549953d7598008a3eb9c630ab5deaf5f37c2fa0d033262739cf38e3da873dfdd9685a",
+        "dest": "nuget-sources",
+        "dest-filename": "system.runtime.compilerservices.unsafe.4.5.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.6.0/system.runtime.compilerservices.unsafe.4.6.0.nupkg",
+        "sha512": "fb9cd0d29dd0a1215894b53d1bd7fa5e7f16922ebc204128293e71c4af1e80aaaff31515d8a919736be969eeeba8070860587e11d9a76c45fc1e13e1e67581cd",
+        "dest": "nuget-sources",
+        "dest-filename": "system.runtime.compilerservices.unsafe.4.6.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.extensions/4.3.0/system.runtime.extensions.4.3.0.nupkg",
+        "sha512": "680a32b19c2bd5026f8687aa5382aea4f432b4f032f8bde299facb618c56d57369adef7f7cc8e60ad82ae3c12e5dd50772491363bf8044c778778628a6605bbc",
+        "dest": "nuget-sources",
+        "dest-filename": "system.runtime.extensions.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.extensions/4.3.1/system.runtime.extensions.4.3.1.nupkg",
+        "sha512": "5526c1370dd4431b879386802cfb18a35e7897e4ca511e088fe363f463e7c8993302631ec18d40c875ee684f8a089e89063d92a0ee2ec0ba98e0e44a5bd2514f",
+        "dest": "nuget-sources",
+        "dest-filename": "system.runtime.extensions.4.3.1.nupkg"
     },
     {
         "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.handles/4.3.0/system.runtime.handles.4.3.0.nupkg",
         "sha512": "0a5baf1dd554bf9e01bcb4ce082cb26ee82b783364feb47cba730faeecd70edc528efad0394dcce11f37d7f9507f8608f15629ebaf051906bfd3513e46af0f11",
-        "dest": "LocalNugetPackages",
+        "dest": "nuget-sources",
         "dest-filename": "system.runtime.handles.4.3.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.handles/4.0.1/system.runtime.handles.4.0.1.nupkg",
-        "sha512": "966a943195b66118277a340075609676e951216d404478ac55196760f0b7b2bd9314bfbb38051204a1517c53097bd656e588e8ab1ec336ce264957956695848a",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.runtime.handles.4.0.1.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.interopservices/4.3.0/system.runtime.interopservices.4.3.0.nupkg",
+        "sha512": "650799c3e654efbb9ad67157c9c60ce46f288a81597be37ce2a0bf5d4835044065ef3f65b997328cbbbbfb81f4c89b8d7e7d61380880019deee6eb3f963f70d9",
+        "dest": "nuget-sources",
+        "dest-filename": "system.runtime.interopservices.4.3.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.extensions/4.3.0/system.text.encoding.extensions.4.3.0.nupkg",
-        "sha512": "e648c5dc781e35cf00c5cc8e7e42e815b963cf8fb788e8a817f9b53e318b2b42e2f7a556e9c3c64bf2f6a2fd4615f26ab4f0d4eb713a0151e71e0af3fe9c3eed",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.text.encoding.extensions.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.interopservices.runtimeinformation/4.3.0/system.runtime.interopservices.runtimeinformation.4.3.0.nupkg",
+        "sha512": "6f4905329a3cc9e62d274c885f275ee31c5af57a6c9fd1a5080d039cb748e0277bef3dc8ce42863cac78365084e00a032279bf3d2b7254a49f3fb1566a29ad1b",
+        "dest": "nuget-sources",
+        "dest-filename": "system.runtime.interopservices.runtimeinformation.4.3.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.extensions/4.0.11/system.text.encoding.extensions.4.0.11.nupkg",
-        "sha512": "b2ba1f2a96bf14466fb31e4ac1fad25e7032688357340ad8976b8aafe7cbe39c061835a4e17d7cf6ae291d3155f07d3371f6b65ffc1c15474c3c86dbb7735e82",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.text.encoding.extensions.4.0.11.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.numerics/4.3.0/system.runtime.numerics.4.3.0.nupkg",
+        "sha512": "3e347faa8e7ec484d481e53b1c219fe1ce346ae8278a214b4508cf0e233c1627bd9c6c6c7c654e8c1f4143271838ddd9593f63a1043577ad87c40e392af7fd34",
+        "dest": "nuget-sources",
+        "dest-filename": "system.runtime.numerics.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.serialization.primitives/4.3.0/system.runtime.serialization.primitives.4.3.0.nupkg",
+        "sha512": "fcf73baadf5675029e91f2e6e4a71c305eece3671ef69f49440f9c6da160d7b33f0a73923d652f2987f7668093f74ed83de72b185de2ce6ec6b37c6e821217ae",
+        "dest": "nuget-sources",
+        "dest-filename": "system.runtime.serialization.primitives.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.claims/4.3.0/system.security.claims.4.3.0.nupkg",
+        "sha512": "ab72b90801f6c051a2b31645448eebfca74642b3cfa1d51f80e21a0d0d7ad44d3366dea139347e2852781b7f3bae820df16c3eb188a2c96244df05394ed72c86",
+        "dest": "nuget-sources",
+        "dest-filename": "system.security.claims.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.algorithms/4.3.0/system.security.cryptography.algorithms.4.3.0.nupkg",
+        "sha512": "7641d70c2ba6f37bf429d5d949bda427f078098c2dcb8924fd79b23bb22c4b956ef14235422d8b1cc5720cbbcc6cfee8943d5ff87ce7abf0d54c5e8bce2aa5e2",
+        "dest": "nuget-sources",
+        "dest-filename": "system.security.cryptography.algorithms.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.cng/4.3.0/system.security.cryptography.cng.4.3.0.nupkg",
+        "sha512": "6272273414eaa777e78dca1b5ecbbdf65e9659908082aea924df0975e71f4c1b47f85617edf90ead57078c29513a160ca62f123be9f9f339dfb9c9386844f5ea",
+        "dest": "nuget-sources",
+        "dest-filename": "system.security.cryptography.cng.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.csp/4.3.0/system.security.cryptography.csp.4.3.0.nupkg",
+        "sha512": "43317591747a18f52f683187e09adfe0e03573e6dac430bf3ba13f440cdb1c7bb1f9205369d5f3b2a0f3fdf9604d5ba1e6d94a899a25d2c533e453338578f351",
+        "dest": "nuget-sources",
+        "dest-filename": "system.security.cryptography.csp.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.encoding/4.3.0/system.security.cryptography.encoding.4.3.0.nupkg",
+        "sha512": "5c26add23e63542f37506f5fa1f72e8980f03743d529cd8e583d1054b8d8a579fb773fa035a00d9073db84db6be4f47cac340d1ebc6d23dd761dbdbd600075e0",
+        "dest": "nuget-sources",
+        "dest-filename": "system.security.cryptography.encoding.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.openssl/4.3.0/system.security.cryptography.openssl.4.3.0.nupkg",
+        "sha512": "64530a19489730f873f8c68e6b245135ea260c02d68591880261768358d0145795132ba5ee877741822ff05dcd0c61edca27696ef99e8f9302a21cadf3b1329f",
+        "dest": "nuget-sources",
+        "dest-filename": "system.security.cryptography.openssl.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.primitives/4.3.0/system.security.cryptography.primitives.4.3.0.nupkg",
+        "sha512": "5ad8273f998ebb9cca2f7bd03143d3f6d57b5d560657b26d6f4e78d038010fb30c379a23a27c08730f15c9b66f4ba565a06984ec246dfc79acf1a741b0dd4347",
+        "dest": "nuget-sources",
+        "dest-filename": "system.security.cryptography.primitives.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.x509certificates/4.3.0/system.security.cryptography.x509certificates.4.3.0.nupkg",
+        "sha512": "318d86ab5528e2b444ec3e4b9824c1be82bb93db513eab34b238e486f886c4d74310ed82c2110401fe5cd790e4d97f4a023a0b2d5c2e29952d3fd02e42734d00",
+        "dest": "nuget-sources",
+        "dest-filename": "system.security.cryptography.x509certificates.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.principal/4.3.0/system.security.principal.4.3.0.nupkg",
+        "sha512": "db8a1ed0d189637d9ef83147550ce5da890cf6ec189a7d006ba9de86ab55679e7f025e18bdaed2dc137ddf82a7e6a0131fb4d54d4264831862b1d7c5ee62837e",
+        "dest": "nuget-sources",
+        "dest-filename": "system.security.principal.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.principal.windows/4.3.0/system.security.principal.windows.4.3.0.nupkg",
+        "sha512": "66c1d5a9d649b964e1653fa2cd41d8f80515b7cd727fcd7f0890552070da1099ecd1032560f259a108e0d1d6a6da23fa07bc5c922f426a91f33b667f7c004019",
+        "dest": "nuget-sources",
+        "dest-filename": "system.security.principal.windows.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.principal.windows/4.7.0/system.security.principal.windows.4.7.0.nupkg",
+        "sha512": "f30a16d34c8792db60b2240363a8b200cab28bc2c7441405cf19abf71dbf5fb0bf3bd1cbec4d9b5eb4cf73ec482e4505d08d80afdef00b2b4b3bb56d6d4cae96",
+        "dest": "nuget-sources",
+        "dest-filename": "system.security.principal.windows.4.7.0.nupkg"
     },
     {
         "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding/4.3.0/system.text.encoding.4.3.0.nupkg",
         "sha512": "6ff7feec7313a7121f795ec7d376e4b8728c17294219fafdfd4ea078f9df1455b4685f0b3962c3810098e95d68594a8392c0b799d36ec8284cd6fcbd4cfe2c67",
-        "dest": "LocalNugetPackages",
+        "dest": "nuget-sources",
         "dest-filename": "system.text.encoding.4.3.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding/4.0.11/system.text.encoding.4.0.11.nupkg",
-        "sha512": "f974335143f36b318abf040ed535887f28089d749b1fa55056345df5243dfbd56d27b74c6e4d87a737fdbb8e699c5291bd25f1e5db4700bb00bf53330c7e3e9a",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.text.encoding.4.0.11.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.codepages/4.5.1/system.text.encoding.codepages.4.5.1.nupkg",
+        "sha512": "12edddc9452a0c592eb24aeb2b9e152d60b8d44540349368e6fce3a239c6029847f8557adcd260df3b39c744ef45a6034d9db2fbce9e20e2b8dc78363578b0ef",
+        "dest": "nuget-sources",
+        "dest-filename": "system.text.encoding.codepages.4.5.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.regularexpressions/4.1.0/system.text.regularexpressions.4.1.0.nupkg",
-        "sha512": "9b612027e43c33cc256e016e0b400547c5923e93ab6ed1a40d2b97292cb18a1195fa79aba2b0166a6b11842a0fef6685d31b848375daffdf6d2acf297af40bbe",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.text.regularexpressions.4.1.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.extensions/4.3.0/system.text.encoding.extensions.4.3.0.nupkg",
+        "sha512": "e648c5dc781e35cf00c5cc8e7e42e815b963cf8fb788e8a817f9b53e318b2b42e2f7a556e9c3c64bf2f6a2fd4615f26ab4f0d4eb713a0151e71e0af3fe9c3eed",
+        "dest": "nuget-sources",
+        "dest-filename": "system.text.encoding.extensions.4.3.0.nupkg"
     },
     {
         "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/system.text.regularexpressions/4.3.0/system.text.regularexpressions.4.3.0.nupkg",
         "sha512": "80353c148df30d9a2c03ee10a624d91b64d7ccc3218cb966344cfa70657f0b59c867fed2ab94057f64ab281ad9318353f25c23375c00e1376b6589ae0a70aad3",
-        "dest": "LocalNugetPackages",
+        "dest": "nuget-sources",
         "dest-filename": "system.text.regularexpressions.4.3.0.nupkg"
     },
     {
         "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/system.threading/4.3.0/system.threading.4.3.0.nupkg",
         "sha512": "97a2751bdce69faaf9c54f834a9fd5c60c7a786faa52f420769828dbc9b5804c1f3721ba1ea945ea1d844835d909810f9e782c9a44d0faaecccb230c4cd95a88",
-        "dest": "LocalNugetPackages",
+        "dest": "nuget-sources",
         "dest-filename": "system.threading.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading/4.0.11/system.threading.4.0.11.nupkg",
-        "sha512": "05c0dd1bbcfcedb6fc6c5f311c41920a4775f8a28a61ca246b6c65ad8afd9b04881d3357880af000ac056fd121fc5c3ec0b56d6fd607e0c27e7a639157c85e3e",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.threading.4.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.objectmodel/4.0.12/system.objectmodel.4.0.12.nupkg",
-        "sha512": "f5191cdb360bd2624abd7454c66862540f97aa19df92ea0854786b9d3cb9549e95c6194cfe8adc01589203c4feb1673a129c4929486bcb5f8db83ea535477c53",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.objectmodel.4.0.12.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.objectmodel/4.3.0/system.objectmodel.4.3.0.nupkg",
-        "sha512": "409bca3d2139bd1d003c711400ba2db5e576bb54d593aa541ec3576e7b2029b60159ab1c5b2c4e7389267b1b95ebcd8c2f064dc6e1f53e693aacb1737f066123",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.objectmodel.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io/4.3.0/system.io.4.3.0.nupkg",
-        "sha512": "bfca5a21e3e1986b9765b13dc6fbcd6f8b89e4c1383855d1d7ef256bf1bf2f51889769db5365859dd7606fbf6454add4daeb3bab56994ffb98fd1d03fe8bc1e6",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.io.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io/4.1.0/system.io.4.1.0.nupkg",
-        "sha512": "e01b432f3d715f3c88d5d7f3e7cc1ceee78caf99407a11c3306f9103aee78963f818417f14eec52f0096fa247900a31e53bd3226e06f0c0f93870db0b2b78331",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.io.4.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.resources.resourcemanager/4.3.0/system.resources.resourcemanager.4.3.0.nupkg",
-        "sha512": "9067db28f1c48d08fc52ad40a608f88c14ad9112646741ddaf426fdfe68bed61ab01954b179461e61d187371600c1e6e5c36c788993f5a105a64f5702a6b81d4",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.resources.resourcemanager.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.resources.resourcemanager/4.0.1/system.resources.resourcemanager.4.0.1.nupkg",
-        "sha512": "5165916e258dd38fa83278fb98dce271a95e0091c1274b8cf5f17d88b9e6284f7a7bf145194afe4f20250cc31ad714141f9e0687cf235ff05460fb47cea0c525",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.resources.resourcemanager.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.emit.ilgeneration/4.0.1/system.reflection.emit.ilgeneration.4.0.1.nupkg",
-        "sha512": "c3819cd3a58f609ff579652536f9f414481caa4d9e7dc277e0d3c8c8fe8e0ff90806fa94f7c6436d4af853c6fccd26d5af57f0a49c5baceef4e0daaa39e26773",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.reflection.emit.ilgeneration.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.emit.ilgeneration/4.3.0/system.reflection.emit.ilgeneration.4.3.0.nupkg",
-        "sha512": "e9be5f62bf64b1947a49857337306a5d0980686b58d665989e94006ab04aa7e0bbf4d8543d1b57d5bb38079052f275f339b73054a7357e4fa357208a0ac85d69",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.reflection.emit.ilgeneration.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.emit/4.0.1/system.reflection.emit.4.0.1.nupkg",
-        "sha512": "ff7766886b945148ea65a49e4ddc648336340def2c2e94b8277b584444ec9126d96918f0bcbeb62016a530623a89ccd9eae749d62065b01058387b5d09fc7dd1",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.reflection.emit.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.emit/4.3.0/system.reflection.emit.4.3.0.nupkg",
-        "sha512": "be45051467a36ab965410f112a475fb81510a5595347d1cc0c46b028e0436a339218dd3c073f048c2d338b67dc13b45742290b6c46f55982503f74a8f2698818",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.reflection.emit.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.extensions/4.0.1/system.reflection.extensions.4.0.1.nupkg",
-        "sha512": "3e2f07c29836735be6247e75f760de90783d5ece64e8cce4e23eceb777da8975a35130804d87ddd26449c13d2ca34180e3f6b844b0fdd2dc594bbec6e7272098",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.reflection.extensions.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.extensions/4.3.0/system.reflection.extensions.4.3.0.nupkg",
-        "sha512": "06cfd992c8d7fd9ab6432ab02be981a01b6558285a6e26a7825a064d4efcce08d9e7344f03fa19b033a2459d42b0b80e8c1400ce39b47a1752869ab8825b0475",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.reflection.extensions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.openssl/4.0.0/system.security.cryptography.openssl.4.0.0.nupkg",
-        "sha512": "432629e457c7061a7d207fb60597a5a8a806fab8c62574833e509afa3c4ac8fed529dbc7f21d69e16dc9fdd091aaa575191e9fb552eedcf28aaa8b5954d32e9b",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.security.cryptography.openssl.4.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.openssl/4.3.0/system.security.cryptography.openssl.4.3.0.nupkg",
-        "sha512": "64530a19489730f873f8c68e6b245135ea260c02d68591880261768358d0145795132ba5ee877741822ff05dcd0c61edca27696ef99e8f9302a21cadf3b1329f",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.security.cryptography.openssl.4.3.0.nupkg"
     },
     {
         "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks/4.3.0/system.threading.tasks.4.3.0.nupkg",
         "sha512": "7d488ff82cb20a3b3cef6380f2dae5ea9f7baa66bf75ad711aade1e3301b25993ccf2694e33c847ea5b9bdb90ff34c46fcd8a6ba7d6f95605ba0c124ed7c5d13",
-        "dest": "LocalNugetPackages",
+        "dest": "nuget-sources",
         "dest-filename": "system.threading.tasks.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks/4.0.11/system.threading.tasks.4.0.11.nupkg",
-        "sha512": "fb66c496a5b4c88c5cb6e9d7b7d220e10f2fc0aed181420390f12f8d9986a1bd2829e9f1bf080bb6361cd8b8b4ffc9b622288dfa42124859e1be1e981b5cfa7b",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.threading.tasks.4.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.csp/4.0.0/system.security.cryptography.csp.4.0.0.nupkg",
-        "sha512": "6f3fb8256086a16ed7fe339e0f09d42a081c4f783b0f8626bb7eec08261532ecf517f6c7a41bfbb8e2b99b8f1c79ef99ef7c724d8719e287fe7981ebe8b6aa8e",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.security.cryptography.csp.4.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.csp/4.3.0/system.security.cryptography.csp.4.3.0.nupkg",
-        "sha512": "43317591747a18f52f683187e09adfe0e03573e6dac430bf3ba13f440cdb1c7bb1f9205369d5f3b2a0f3fdf9604d5ba1e6d94a899a25d2c533e453338578f351",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.security.cryptography.csp.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.collections/4.3.0/system.collections.4.3.0.nupkg",
-        "sha512": "ca7b952d30da1487ca4e43aa522817b5ee26e7e10537062810112fc67a7512766c39d402f394bb0426d1108bbcf9bbb64e9ce1f5af736ef215a51a35e55f051b",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.collections.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.collections/4.0.11/system.collections.4.0.11.nupkg",
-        "sha512": "f61b75329ba5d7c0e688aa9d110b2200c8934c3a1888f6b1b5f198baa7ab93f23835e8380853e8c046f257172b5060578ed86df26e5fe0ef34d8c4408a02c33f",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.collections.4.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.cng/4.2.0/system.security.cryptography.cng.4.2.0.nupkg",
-        "sha512": "4ed77501662e6d18733f507077de9d277b61b3d2dacee791e0b3a56c9a604bd2acfb81334c51660ba33bb7a6e24ed46c2da02716f6613a937152ea4806540bf1",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.security.cryptography.cng.4.2.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.cng/4.3.0/system.security.cryptography.cng.4.3.0.nupkg",
-        "sha512": "6272273414eaa777e78dca1b5ecbbdf65e9659908082aea924df0975e71f4c1b47f85617edf90ead57078c29513a160ca62f123be9f9f339dfb9c9386844f5ea",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.security.cryptography.cng.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.extensions/4.3.0/system.runtime.extensions.4.3.0.nupkg",
-        "sha512": "680a32b19c2bd5026f8687aa5382aea4f432b4f032f8bde299facb618c56d57369adef7f7cc8e60ad82ae3c12e5dd50772491363bf8044c778778628a6605bbc",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.runtime.extensions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.extensions/4.1.0/system.runtime.extensions.4.1.0.nupkg",
-        "sha512": "42d009be57d6497aa0724924891289f3decd916d0432c1c865cc0494092f5e59287f632a70c5060b3c78e361ab04510d75dfb3c2d2853f54201f735eb6e2dea6",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.runtime.extensions.4.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.debug/4.3.0/system.diagnostics.debug.4.3.0.nupkg",
-        "sha512": "6c58fe1e3618e7f87684c1cea7efc7d3b19bd7df8d2535f9e27b62c52f441f11b67b21225d6bcd62f409e02c2a16231c4db19be33b8fab5b9b0a5c8660ddab24",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.diagnostics.debug.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.debug/4.0.11/system.diagnostics.debug.4.0.11.nupkg",
-        "sha512": "02f4d0bf969eb1a876def21c1ffd75f8ed5f979aed9a1169f409e60a6e07016854e2154da5c0164fabaeaf6527a18d8e67282db1b69327a1b3581e9c0c742f58",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.diagnostics.debug.4.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.buffers/4.3.0/system.buffers.4.3.0.nupkg",
-        "sha512": "3dcbf66f6edf7e9bb4f698cddcf81b9d059811d84e05c7ac618b2640efed642f089b0ef84c927c5f58feffe43bb96a6bcf4fec422529b82998b18d70e4648cbe",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.buffers.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.buffers/4.0.0/system.buffers.4.0.0.nupkg",
-        "sha512": "0663f4639c4e37c9dff12717cdeaebf30e38d91e986d6a99f9f16ba88189873e0399e418659e732a18c674d8875f8f41a1cf60319604173ca8430960759fddf2",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.buffers.4.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.filesystem/4.3.0/system.io.filesystem.4.3.0.nupkg",
-        "sha512": "4fb581d6f85b9529a091a0e974633752aa39e50b2be6c8a9e5eca8c2bc225cea07064ccec7778f77df9987deebf4dccec050b1a97edac0ee9107142e6a8ee7ee",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.io.filesystem.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.filesystem/4.0.1/system.io.filesystem.4.0.1.nupkg",
-        "sha512": "a6478b17f5d52fc5b9517458e93e1a69b92575c170f44046b3f4e25c7e67c9d4126ab486f5a3c51abcb279d05a057bd53aa8f49a1e51eae69563ae39214b72d3",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.io.filesystem.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.threadpool/4.3.0/system.threading.threadpool.4.3.0.nupkg",
-        "sha512": "450a40f94a48e9396979e764e494ad624d8333f3378b91ea69b23fc836df8f5c43bbd6c8cfd91da2ab95a476e1ff042338968e09b720447f2241c014bfc75159",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.threading.threadpool.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.threadpool/4.0.10/system.threading.threadpool.4.0.10.nupkg",
-        "sha512": "76ea4b3a95414976f71bf01bf6eb4b55b398c59fa19eae44c55cfa0e4f42065cd79ba667c3518020ebf91c48e5904099273e3423cce18716891d656c58ee3ce1",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.threading.threadpool.4.0.10.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tracing/4.3.0/system.diagnostics.tracing.4.3.0.nupkg",
-        "sha512": "d0a5d30e261cd45b7dfab02b7ffbd76b64e0c9b892ed826ea61481c983c0208b05b69981cd79e91cd4e5811e1cd4c3cea06a1afce05811ece58be5e4c20169ea",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.diagnostics.tracing.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tracing/4.1.0/system.diagnostics.tracing.4.1.0.nupkg",
-        "sha512": "0c64f255836cb629587b117bd8de5e70bfe7e4c6d7d138bff10b9e85f4883fba250ae07118c21d5e9130ba3cf120a9a2bf581a17577d3a7ec09260933c7b4d47",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.diagnostics.tracing.4.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization/4.3.0/system.globalization.4.3.0.nupkg",
-        "sha512": "823d2ba308cb073b40a3146ecccd0d9fd7b1615ac3fbefb16f73d873e411fd81c3bdc87df206d3dc7e2f14c9cd53aafca684a3570c25471280aada8de805ece2",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.globalization.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization/4.0.11/system.globalization.4.0.11.nupkg",
-        "sha512": "66bc21667f5f839bc711eda3b0463863d70e0ad86770fd5410e0123006d6f031755cf7220187fb7cefed69b3f4a9eab8f0868cae765cb1425c8bf60427f395e6",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.globalization.4.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.nameresolution/4.3.0/system.net.nameresolution.4.3.0.nupkg",
-        "sha512": "40d39e131fe7a392e58e9f58b516b5db88383de91c05b771f5e509acf46cc874271e90623d327ab039003ab8f2714144694390261278de324e1aee228a828ab4",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.net.nameresolution.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.nameresolution/4.0.0/system.net.nameresolution.4.0.0.nupkg",
-        "sha512": "b737933f4afcb8c7f5d0b56b6f0ba30e24124d7349ce3968d8baae455ddbe451de13638dc1ef84657f715661be28561a27214d6f6b133411c0d64d6d7d252097",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.net.nameresolution.4.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.numerics/4.0.1/system.runtime.numerics.4.0.1.nupkg",
-        "sha512": "333a3ba974e80ee66d33a9d8412e0bd585350bd30ecc65ed35e9d7c69284dbb90bc8b8d019c40476f3277049e0c7ae9b05a7d1e27614f057f39a141132304cd4",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.runtime.numerics.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.numerics/4.3.0/system.runtime.numerics.4.3.0.nupkg",
-        "sha512": "3e347faa8e7ec484d481e53b1c219fe1ce346ae8278a214b4508cf0e233c1627bd9c6c6c7c654e8c1f4143271838ddd9593f63a1043577ad87c40e392af7fd34",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.runtime.numerics.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/netstandard.library/1.6.1/netstandard.library.1.6.1.nupkg",
-        "sha512": "0972dc2dbb4925e896f62bce2e59d4e48639320ee38ad3016dcd485fbd6936a0ed08073ad5eef2a612dff05dfc390f3930fff9e79d87a06070eeb8128277cbd0",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "netstandard.library.1.6.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/netstandard.library/1.6.0/netstandard.library.1.6.0.nupkg",
-        "sha512": "9838af4e2a3621de24d117c7fa58e5e8f170e50ea4e0ae3fe3d3401dfadbefd6eb5ecc3b64532c8340f6340727822eed305ef3bc21629f2bb6d76c639d054925",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "netstandard.library.1.6.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.componentmodel.annotations/4.5.0/system.componentmodel.annotations.4.5.0.nupkg",
-        "sha512": "7f5029507196abf9490bc3d913b26a6c0ded898ed99e06503b699b61f086d0995055552aaa654c032d1f32f03012e1badfd338ec42dd3fa3d0c5ce4e228ea2e8",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.componentmodel.annotations.4.5.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.componentmodel.annotations/4.1.0/system.componentmodel.annotations.4.1.0.nupkg",
-        "sha512": "ef92333f99ca0626e0409100b6f5077fa814a51c78dc558ab1313a74ae69090e05dbfaf764418ba51b979beebd563065e4ba432e0d1181afd0ae1ddaecbf5924",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.componentmodel.annotations.4.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reactive/4.1.5/system.reactive.4.1.5.nupkg",
-        "sha512": "b5468ffcad3c503f7cdd84a57d79c3678c3d32af48e2c1590587e1fc01145b78120b8ab197b16ddce4506753ea36c4dbeaa636231f31dd3b7fa8da50fd81b4b4",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.reactive.4.1.5.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reactive/4.1.6/system.reactive.4.1.6.nupkg",
-        "sha512": "bc204c80c6b527864abf225d9d2eab977056887e5467aa8bbb63728f1cc1c48875f88c90fda3d4b3c03b1db64109a427a1ced8f79f9dcd5dfe3c8f96c5e41ba6",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.reactive.4.1.6.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/reactiveui/10.3.6/reactiveui.10.3.6.nupkg",
-        "sha512": "050ec7ed2114b0c4d17bb8b26f9afad40167113ea0c27c93c895005c7d44c582be6391f6609c9baeb5b0eedfdac146df88ca7d2fa3921601f3f226a4844ef0b9",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "reactiveui.10.3.6.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.memory/4.5.3/system.memory.4.5.3.nupkg",
-        "sha512": "70fce15a52cc76aacbae05c8e89e2e398d1d32903f63f640a7dd4a3e5747f2c7a887d4bfd22f2a2e40274906cf91648dfd169734fb7c74eb9b4f72614084e1db",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.memory.4.5.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.memory/4.5.0/system.memory.4.5.0.nupkg",
-        "sha512": "50b3838aa76af357bd61f412fc62f83f9ce07a4f748f23f2900578b754a9e2c8c80f7fc46e2d7c95bbce2a6fbcd5b8874796b915d1515d253f25573a9f1affec",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.memory.4.5.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.memory/4.5.2/system.memory.4.5.2.nupkg",
-        "sha512": "3a17fd87a7a6e428cf680ceea46b56fd358ccd7e9a55f2063e1edbab929099fbd826bf83aaf39ad1c452f6080528622ebca4cca1d09011a7060bf0b013c8fb72",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.memory.4.5.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.6.0/system.runtime.compilerservices.unsafe.4.6.0.nupkg",
-        "sha512": "fb9cd0d29dd0a1215894b53d1bd7fa5e7f16922ebc204128293e71c4af1e80aaaff31515d8a919736be969eeeba8070860587e11d9a76c45fc1e13e1e67581cd",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.runtime.compilerservices.unsafe.4.6.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.5.0/system.runtime.compilerservices.unsafe.4.5.0.nupkg",
-        "sha512": "91433424f3077ddb5e7869bfafdfed765b1d74f5753d4900cdc814b5c53b2d79f96582a85d4cab3e9f4e6ab042cb72514b99e4ec1b7077e5cc304aa14b3aee34",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.runtime.compilerservices.unsafe.4.5.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.debug/1.0.0/serilog.sinks.debug.1.0.0.nupkg",
-        "sha512": "319181368939238f1a58ff895d76305fc53d70a24e14fb4d135c60158e1998778a7078ff2632b9ad78b29c3a9f8adc798625b26cd54a4c6d5eb5a00082b7eaa4",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "serilog.sinks.debug.1.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.valuetuple/4.5.0/system.valuetuple.4.5.0.nupkg",
-        "sha512": "fa00ebb5045d12c51274f64411c551981beceb1266a8606a4731063109b95ea1f15939197bf3d2ba899db61e593dc39bfce876908bba34286823525093ae3d8e",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.valuetuple.4.5.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.remote.protocol/0.9.2/avalonia.remote.protocol.0.9.2.nupkg",
-        "sha512": "392829120451a2d40be639ba45340152482182c248aee80e1c7e8d4eac68e13d7037b91cde863e4074a63797c6ab2a35f90adeca01efe250b71e11ceb98010ba",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "avalonia.remote.protocol.0.9.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.trace/2.1.0/serilog.sinks.trace.2.1.0.nupkg",
-        "sha512": "eaa6dc41cb95a7d13d39e0a7f85e2422b5f3885d5e72c90e8a88adb0b23878a2fee31101dcad0de99e57792e6dd9ce0387818cb02eb3111837a37c83dd89064b",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "serilog.sinks.trace.2.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/jetbrains.annotations/10.3.0/jetbrains.annotations.10.3.0.nupkg",
-        "sha512": "ad0c0fdda8d66adbb5da6c83b562df9c45b1cb7ec146c892747cbfdcf4409b1e9d620840378cceb2a94889d7e4d3cd4318347b736eca97e801e59d2dcfb78afc",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "jetbrains.annotations.10.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.timer/4.0.1/system.threading.timer.4.0.1.nupkg",
-        "sha512": "6aa43dc5b3914050850b8ddafcc2256e60670d51c0f1b38b0d26d80f36e76cf5b40d6053bf92b4abecce5f786de5b13daa70eddf541865509c7a73fe3785de4b",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.threading.timer.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.timer/4.3.0/system.threading.timer.4.3.0.nupkg",
-        "sha512": "d5ce8e258b7be7be268f944e21621195948106f57e6c46e69b2887c46f567760368b14e84046b4be4466ecd08ecd4cb04016a2ff7948cb4640960befc7aa1739",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.threading.timer.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.win32/0.9.2/avalonia.win32.0.9.2.nupkg",
-        "sha512": "b64e6cd4962671bc527e265f689b8343140760ea04a04e25b969dc50a6e9e83b6101296a365c15d95fbe2dc6c8b509e7babd2f3236c805750c68d2fac71b6646",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "avalonia.win32.0.9.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.x11/0.9.2/avalonia.x11.0.9.2.nupkg",
-        "sha512": "050af6f7f528184ad25b2efba3e63fb251edebcd6866e4b374c6a070c8ac9240b665f7146734e1e5410f3da55398b2271b9a78e0deea0799f665ac08acab2749",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "avalonia.x11.0.9.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization.calendars/4.0.1/system.globalization.calendars.4.0.1.nupkg",
-        "sha512": "e6f3f0fc443c52cbe754ccfe6c7752206557db7603187b0f1ab7e21fcb466248ee20844d9ce9f5f114e6daa5944a3293cca47f3c02a2e735a7b494f29f2278c0",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.globalization.calendars.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization.calendars/4.3.0/system.globalization.calendars.4.3.0.nupkg",
-        "sha512": "e97190231402b393774b925efc02a2bfa41d1d117a17fb87da6e399f5234546962767e9cd8f39970efa408e4f453cd1e6751a2a61e366bc97406e1b0b8a4be86",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.globalization.calendars.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.net.http/4.0.1/runtime.native.system.net.http.4.0.1.nupkg",
-        "sha512": "ad933eb14740a111a81b5de6837dd0fc9390dde308fedf4338a498f97cd40ecfc65c745802e92c8ec8543d75dd262ebfef476df2e646b63cd99c609258d1bbd9",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.native.system.net.http.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.net.http/4.3.0/runtime.native.system.net.http.4.3.0.nupkg",
-        "sha512": "ddd1e5b67545477f7c72b5883666de40e89efb0836d91e7a349e2f3d4ac05ce1125e6add3cb09c39cbdfe7ab7c5dc8fdaeaf6ac25acd92f6de3d8ce2d6db7918",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.native.system.net.http.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.private.uri/4.3.0/runtime.unix.system.private.uri.4.3.0.nupkg",
-        "sha512": "203ebe272791d79ab0c40afe9d0543852ee91b9fb4ae5bc15524d97728bc8bc9d7e0cbcf65d1fab8cfb0aa7a4ae37e7938933eef127aa5ea46f60e57b6ad2d91",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.unix.system.private.uri.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.linq/4.1.0/system.linq.4.1.0.nupkg",
-        "sha512": "53e53220e5fdd6ad44f498e4657503780bca1f73be646009134150f06a76b0873753db3aae97398054bd1e8cc0c1c4cdd2db773f65a26874ab94110edb0cddb1",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.linq.4.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.linq/4.3.0/system.linq.4.3.0.nupkg",
-        "sha512": "eacc7fe1ec526f405f5ba0e671f616d0e5be9c1828d543a9e2f8c65df4099d6b2ea4a9fa2cdae4f34b170dc37142f60e267e137ca39f350281ed70d2dc620458",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.linq.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.native/0.9.2/avalonia.native.0.9.2.nupkg",
-        "sha512": "a8aa56dfd0f003508da061e15b95fc570e1d0548b7797c144cfaf186445428ff084fe374864f202ddfcedcc601077bcdac67191157d933a72ea38ef24b1c0b99",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "avalonia.native.0.9.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.direct2d1/0.9.2/avalonia.direct2d1.0.9.2.nupkg",
-        "sha512": "abbd4194b35c30a92aaf64d92b2edc5cf83891759051c9c7f85b3c405d0bd43a248d6e3a20967629531e17bf206cf010d2a53e21cbb1531796d298aead6361f5",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "avalonia.direct2d1.0.9.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.skia/0.9.2/avalonia.skia.0.9.2.nupkg",
-        "sha512": "1cae040f0765003286ffc8eb1e9df97b358b4c2d14f81e64145ba1fe1d8aa983bd4550d00e39cd5fbc6a02f5fd945b316806f36cf202857cdb58fb5b934aeddb",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "avalonia.skia.0.9.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.targets/1.1.0/microsoft.netcore.targets.1.1.0.nupkg",
-        "sha512": "1ef033a68688aab9997ec1c0378acb1638b4afb618e533fcaf749d93389737ba94f4a0a94481becdf701c7e988ae2fe390136a8eae225887ee60db45063490fe",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.netcore.targets.1.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.targets/1.0.3/microsoft.netcore.targets.1.0.3.nupkg",
-        "sha512": "67f74cce98f313b2ea479b27a145f0580bf4dd91a7e308aca8c187c22c21b6e27f088187425647c077e8edf074f153b7a2a9a2dcb8866d18948def4731b2df8f",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.netcore.targets.1.0.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.targets/1.0.1/microsoft.netcore.targets.1.0.1.nupkg",
-        "sha512": "6ed8e75f945a18651066fe9ee31cf6c8257a5974340fe4d262438903c4959a479f4a515a4d1389e6d3d3ab34f09a3c7bc2009aada2e8a7f697b6655a82d3bfc9",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.netcore.targets.1.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/1.1.0/microsoft.netcore.platforms.1.1.0.nupkg",
-        "sha512": "6bf892c274596fe2c7164e3d8503b24e187f64d0b7bec6d9b05eb95f04086fceb7a85ea6b2685d42dc465c52f6f0e6f636c0b3fddac48f6f0125dfd83e92d106",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.netcore.platforms.1.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/1.0.1/microsoft.netcore.platforms.1.0.1.nupkg",
-        "sha512": "5f3622dafd8fe8f3406c7a7ee506a7363c9955b28819ae1f2b067c38eae7ab6e620eb63442929b967c94fc511e47a2b7547ab62b6f1aafe37daa222499c9bb19",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.netcore.platforms.1.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/2.0.0/microsoft.netcore.platforms.2.0.0.nupkg",
-        "sha512": "0827f83639833a88ac7bb1408a3d953ee1c880a2acbbaf7abe44f084e90f5507cbb13981d962c57d0e3278ee5476d93c143eb7e9404cc7a63d7a8bf324a4fbe8",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.netcore.platforms.2.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/1.0.2/microsoft.netcore.platforms.1.0.2.nupkg",
-        "sha512": "fabfdae455ff17c160f7f3c64d31ad39cf667a60e06776efaf07e99c81dda53500e2bfc827571a53c3ac46a1605dcba9fa007374727fcbfc109287c25a1eca5d",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.netcore.platforms.1.0.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core/2.7.9/humanizer.core.2.7.9.nupkg",
-        "sha512": "6eb689c38e167a80ac50bb5b273c7e55f78acccac17802b0012f230e55de46173f1c476a67f91597aef6babaa74682869edaec68eda7e1686f12c39a9e96646e",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "humanizer.core.2.7.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
-        "sha512": "4981b2d7a106703b185e176ad35bfda149156f3b752778fa71c56b3686407765fd2b6625de352bd563aac1e1e8769d7886cc59a0d5d0bfb41ed60277360beb81",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
-        "sha512": "fd8e32d7d3e9a465202e391b0ab8b95e212900879bc4d8ac22954fd2d0f98fa579e9d25f88885ac2a4bf1eba755db940f8d131250a3ffec34dbe77431a379cab",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
-        "sha512": "4afac5cc1734330a6103880e790d639e825bfb1b34dbd42083762c47db5e5dab6c03efd16049ac03861d7d87746caed09c7534241d51b7341d47ba6af7e8dd31",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
-        "sha512": "5dbe6bc007a9b46491e5299602291f5dbf8cc8d51e6c1b08db2fa0efd365990b41b6e181ed6bf82e873a659396427bc0e33e85b47d645d273fef8bf8ec643631",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
-        "sha512": "c9f219515e268cf40e16b135bd64cba95c35e866dd9bc34954159562314d01d2f9ea7eb8b0db94acf6bdac83d651d90bad7890cb657ffe40fa3440ec662c9944",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
-        "sha512": "e65a6a1f1928cfb760c395a399542dc7f9087399c53874376604504ae60abd2da24ed735ebd148d335000a5e35c8108ea55404685e902df392eac2e8d38fb665",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
-        "sha512": "81bdb93c1c86c560343df6cc367499fb2a01a9b3016617be416874a23c4355a8d95c7be34f175510f3fdea4872302a87c8efab98a328dfa39422db520c3f291c",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
-        "sha512": "b2cf809fe50c4b46bd6f2372265cd3059622550123afceb5dbb2410906c07a7f47bae4273584d29253d5e7a63a17c68c7ba0434608bbc8fd4d00e479b2f128ff",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
-        "sha512": "6de9544b4da49f127680cf5b3b4afea96bfcac3293038a1b0a12eea0ad60be368af31ee1dfd66d48d458b40200738c04aa0c71adcc54ae2dddbea2cd50d6f28d",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.collections.concurrent/4.0.12/system.collections.concurrent.4.0.12.nupkg",
-        "sha512": "a46bd40b8cc7afeaea14c80ee6ab99a5ef6d27e9e897cfe842e9ab5ca04b9de8d7192a310225b1040d57d4870921487acf5df993ab81301d49994048e1341e85",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.collections.concurrent.4.0.12.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.collections.concurrent/4.3.0/system.collections.concurrent.4.3.0.nupkg",
-        "sha512": "35c1aa3e636216fe5dc2ebeb504293e69ad6355d26e22453af060af94d8279faa93bdcfe127aecb0b316c7e7d9185bcac72e994984efdb7f2d8515f1f55cf682",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.collections.concurrent.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
-        "sha512": "61da1667a5dd1e53a5d19fbe90abbfe332d84fe755fb811a080668a47d41a97db44539e3174fd1d2a0770ff1bd83afa68c82ce06df5775da65a6054ccc12c4be",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection/4.3.0/system.reflection.4.3.0.nupkg",
-        "sha512": "2325b67ed60dce0302807064f25422cbe1b7fb275b539b44fba3c4a8ce4926f21d78529a5c34b31c03d80d110f7bace9af9589d457266beac014220057af8333",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.reflection.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection/4.1.0/system.reflection.4.1.0.nupkg",
-        "sha512": "67143ef8f6fb1044830c70c66e9a2b4f1850f50df5dadfaa5177338362ea7b9e9fe4b0ba59cd4eac6e1c8db4e0c285c239e4c2b3ce61391618b411aaff45f7c2",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.reflection.4.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.primitives/4.3.0/system.reflection.primitives.4.3.0.nupkg",
-        "sha512": "d4b9cc905f5a5cab900206338e889068bf66c18ee863a29d68eff3cde2ccca734112a2a851f2e2e5388a21ec28005fa19317c64d9b23923b05d6344be2e49eaa",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.reflection.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.primitives/4.0.1/system.reflection.primitives.4.0.1.nupkg",
-        "sha512": "08ad6f78c5f68af95a47b0854b4ee4360c4bad6e83946c2e45eaa88b48d27d06618c6b7479bd813eb5f30a2db486590d17645e9c0e06a72dbe12ffd37730707e",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.reflection.primitives.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.primitives/4.3.0/system.security.cryptography.primitives.4.3.0.nupkg",
-        "sha512": "5ad8273f998ebb9cca2f7bd03143d3f6d57b5d560657b26d6f4e78d038010fb30c379a23a27c08730f15c9b66f4ba565a06984ec246dfc79acf1a741b0dd4347",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.security.cryptography.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.primitives/4.0.0/system.security.cryptography.primitives.4.0.0.nupkg",
-        "sha512": "a11562f4fd90ff39c12af2078aa3743e323d8a70fe98cfe3d7e0ec182a2166d353c1ed8d76dd2a9525a80287d7dea228f04982edef6584b89f32f72647b2822f",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.security.cryptography.primitives.4.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.encoding/4.3.0/system.security.cryptography.encoding.4.3.0.nupkg",
-        "sha512": "5c26add23e63542f37506f5fa1f72e8980f03743d529cd8e583d1054b8d8a579fb773fa035a00d9073db84db6be4f47cac340d1ebc6d23dd761dbdbd600075e0",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.security.cryptography.encoding.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.encoding/4.0.0/system.security.cryptography.encoding.4.0.0.nupkg",
-        "sha512": "f20d60a5f9affcb49995d1bf27a1c09173ad601147241c4ca504e13324d35f7d6618e8a92d04e174d5d3d9821a03e122fd3b0f8fc1d512d105b6afd73b496c5f",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.security.cryptography.encoding.4.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.windows.apisets/1.0.1/microsoft.netcore.windows.apisets.1.0.1.nupkg",
-        "sha512": "dded90be87a317a63be78ef9920a8a8d76c80e3466cf3aeeccfc4d795d5e2556a119dd05efebe6dedcc37d6d7aacaa2644ebfbda6c4f6b541f4cabeb9cdb2eff",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.netcore.windows.apisets.1.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.jit/1.0.7/microsoft.netcore.jit.1.0.7.nupkg",
-        "sha512": "3b9b275bf50b03a5f8470ecc5ec9db0cfdd67acb8d8de6b34590e0bf64a44d82bef8ffdbd7393e2b836604ba11b0f50ba47774c848ffd67fe11c8fda852eef86",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.netcore.jit.1.0.7.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.dotnethostresolver/1.0.1/microsoft.netcore.dotnethostresolver.1.0.1.nupkg",
-        "sha512": "dc32b37174efdc173121db21bd26858992913f0ce7a7c9e6c2427aa690fb6494c69cb0e911ff5950a7994b5c6a86961fe9a8e8291a5387de1f926ee101dd64b6",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.netcore.dotnethostresolver.1.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.visualbasic/1.3.0/microsoft.codeanalysis.visualbasic.1.3.0.nupkg",
-        "sha512": "141b616d7a6c7b533083271d56ce0adf23003c3328d7637e31b09a2bdd33a8357108555be7926d6486671a1bceca059e0d90bec8db8588d9673b70b1c91136c4",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.codeanalysis.visualbasic.1.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.algorithms/4.3.0/system.security.cryptography.algorithms.4.3.0.nupkg",
-        "sha512": "7641d70c2ba6f37bf429d5d949bda427f078098c2dcb8924fd79b23bb22c4b956ef14235422d8b1cc5720cbbcc6cfee8943d5ff87ce7abf0d54c5e8bce2aa5e2",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.security.cryptography.algorithms.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.algorithms/4.2.0/system.security.cryptography.algorithms.4.2.0.nupkg",
-        "sha512": "93d1e6394afc506b58bd26a9b3ccd64901bc2d48dbb8825ba1f927c17311cad607e6f8a9794cc41aee83b98eed08a23a7c58390b9b852f894735392342f37a3d",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.security.cryptography.algorithms.4.2.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.x509certificates/4.3.0/system.security.cryptography.x509certificates.4.3.0.nupkg",
-        "sha512": "318d86ab5528e2b444ec3e4b9824c1be82bb93db513eab34b238e486f886c4d74310ed82c2110401fe5cd790e4d97f4a023a0b2d5c2e29952d3fd02e42734d00",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.security.cryptography.x509certificates.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.x509certificates/4.1.0/system.security.cryptography.x509certificates.4.1.0.nupkg",
-        "sha512": "6171106ffefaea916a72abf17af038e0203b4e779b7bb75f6fe6cec04c6de3316a7ad4eda8fd3ce7dc0bd8375a0f5e45387456499b24ba22224538cf08a0cae6",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.security.cryptography.x509certificates.4.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.http/4.3.0/system.net.http.4.3.0.nupkg",
-        "sha512": "e8105ce8151aee95852fb29423f73cc1bd7c2286d36474ed7102a4b31248e45f434434a176d3af0442738398c96c5753965ee0444fb9c97525abbd9c88b13e41",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.net.http.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.http/4.1.2/system.net.http.4.1.2.nupkg",
-        "sha512": "175d83ddf934f8050c32848be4fe9882548fb450b2744f7563dbfbc70d904a5bdfb03ca48dd6c7108e73bb57fabcf301356b6c5f3c07cbf020d716fd31dbfeb4",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.net.http.4.1.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.linq.expressions/4.3.0/system.linq.expressions.4.3.0.nupkg",
-        "sha512": "61b90ef9ae6f779fbc8a7b6483ee8f5449cdd05c81b05235f70447e656a73b2aab7c341784b999f7532374744a72e2c3a5cd13800ea23417fac32ccfae5cde6d",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.linq.expressions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.linq.expressions/4.1.1/system.linq.expressions.4.1.1.nupkg",
-        "sha512": "5ea313c89a6cb1dada1e0bbbab8935e00dbeb7390e1bcc8025b9870343849a3e9a5de7fc0c8f8afee5108a9e24a0dfe0cf879c804a3386ae065ea2b2396e14e2",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.linq.expressions.4.1.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.extensions/4.5.2/system.threading.tasks.extensions.4.5.2.nupkg",
-        "sha512": "e470aef15dd007e828b8c6661ab03aebac1e67451046df8e4c3d7aad21371f286ee10865bf191fe274cf23418bcb9dacd2bc608bb0bcb766b2140cf0ed42b5a2",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.threading.tasks.extensions.4.5.2.nupkg"
     },
     {
         "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.extensions/4.3.0/system.threading.tasks.extensions.4.3.0.nupkg",
         "sha512": "2c33900ff7f544d6db31ad11b6baee1c9ecb40d5a54f51e5dd5bbbb37f4c50ee35ed481615cbf7c1da61a31ae3333c4454bfbeee4ae32241789e72ce3f910db6",
-        "dest": "LocalNugetPackages",
+        "dest": "nuget-sources",
         "dest-filename": "system.threading.tasks.extensions.4.3.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.extensions/4.0.0/system.threading.tasks.extensions.4.0.0.nupkg",
-        "sha512": "f294f1a4179f53d59f91f01a372cc7896bf8c322e9827299cb1aa3ae2b1f809e98034834f5ccd4cb3fa1c30735082d244fff6584dab6e8870ad409b55e8a4986",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.threading.tasks.extensions.4.0.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.extensions/4.5.3/system.threading.tasks.extensions.4.5.3.nupkg",
+        "sha512": "10bb263e21c5aefba554ba6e9adcfcc31f9f3692f675665b58cf76b5a5bcc2133d56eedba94f422b30be9ad251edcfeba7ebc24a15ff4cb7838072e9bbb18470",
+        "dest": "nuget-sources",
+        "dest-filename": "system.threading.tasks.extensions.4.5.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.interopservices.windowsruntime/4.3.0/system.runtime.interopservices.windowsruntime.4.3.0.nupkg",
-        "sha512": "041e18e06e501fa8cf96723897c8290f44316da505514cf9e3bf130767f12c1e298196c948a0cb41f0da45e09ba293cf241e4b930b242e8f3a99706ad8ace91e",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.runtime.interopservices.windowsruntime.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.threadpool/4.3.0/system.threading.threadpool.4.3.0.nupkg",
+        "sha512": "450a40f94a48e9396979e764e494ad624d8333f3378b91ea69b23fc836df8f5c43bbd6c8cfd91da2ab95a476e1ff042338968e09b720447f2241c014bfc75159",
+        "dest": "nuget-sources",
+        "dest-filename": "system.threading.threadpool.4.3.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/splat/9.0.5/splat.9.0.5.nupkg",
-        "sha512": "32f884d9dae857db93541943521f31a3476381dcbf41fb2969171d716663c211e779661217a7d4eca939cc40e4b86f1ce5c028ce4216cfc5178d54ef4acb8eee",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "splat.9.0.5.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.timer/4.3.0/system.threading.timer.4.3.0.nupkg",
+        "sha512": "d5ce8e258b7be7be268f944e21621195948106f57e6c46e69b2887c46f567760368b14e84046b4be4466ecd08ecd4cb04016a2ff7948cb4640960befc7aa1739",
+        "dest": "nuget-sources",
+        "dest-filename": "system.threading.timer.4.3.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/dynamicdata/6.13.9/dynamicdata.6.13.9.nupkg",
-        "sha512": "fd0515f0ff0d190be5438b2f53e730e94d69d7257e6da94c828f487242be1f9b4d354a37ce5f87734ad3414c4b58176f977631950a11bd68505f7e90a7ab05ec",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "dynamicdata.6.13.9.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/system.valuetuple/4.5.0/system.valuetuple.4.5.0.nupkg",
+        "sha512": "fa00ebb5045d12c51274f64411c551981beceb1266a8606a4731063109b95ea1f15939197bf3d2ba899db61e593dc39bfce876908bba34286823525093ae3d8e",
+        "dest": "nuget-sources",
+        "dest-filename": "system.valuetuple.4.5.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.serialization.primitives/4.3.0/system.runtime.serialization.primitives.4.3.0.nupkg",
-        "sha512": "fcf73baadf5675029e91f2e6e4a71c305eece3671ef69f49440f9c6da160d7b33f0a73923d652f2987f7668093f74ed83de72b185de2ce6ec6b37c6e821217ae",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.runtime.serialization.primitives.4.3.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/system.xml.readerwriter/4.3.0/system.xml.readerwriter.4.3.0.nupkg",
+        "sha512": "991101497fbd39e43fc306ca280a465318868afa8db1f34bb87c266fe61f0c81a0ec34a797b236ee823bd60d1149b7592def96fe044abb511858efffe890c2e6",
+        "dest": "nuget-sources",
+        "dest-filename": "system.xml.readerwriter.4.3.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tracesource/4.0.0/system.diagnostics.tracesource.4.0.0.nupkg",
-        "sha512": "ab96c6cf3bd7562f9d20c88f591857655eebf8eb374c43ae456e4b1ec0140c6a6a247a25f1788ba24569b2001f3ea1c7364cb1d5b6efe65459a91911ac664ac5",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.diagnostics.tracesource.4.0.0.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/system.xml.xdocument/4.3.0/system.xml.xdocument.4.3.0.nupkg",
+        "sha512": "c2d9236a696daf23a29b530b9aa510fb813041685a1bb9a95845a51e61d870a0615e988b150f5be0d0896ef94b123e97f96c8a43ee815cf5b9897593986b1113",
+        "dest": "nuget-sources",
+        "dest-filename": "system.xml.xdocument.4.3.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.csharp/1.3.0/microsoft.codeanalysis.csharp.1.3.0.nupkg",
-        "sha512": "1f08f8902b8e21c0e72ffa7d40946a028c843e1a1d510f9038304a2a8c7feefb2dcfb94697210ee28cb98c3283a06cb45751458f87e5c6fcb86fe02d1e4113c0",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.codeanalysis.csharp.1.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.drawing.common/4.5.0/system.drawing.common.4.5.0.nupkg",
-        "sha512": "b988b161b074bf3c526dcf41ee3cf0c1403c529a1d6a3de0d99367444596eb3a01c3d0e5b7396d7046b5834238bba011a95274b78137c89016c3987682f26585",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.drawing.common.4.5.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.freedesktop/0.9.2/avalonia.freedesktop.0.9.2.nupkg",
-        "sha512": "54ffd346d23bab23cba803e661b5d96e323dd062469f9745129b4ea34c4e116f7808a85a37ffc7157301f13ca80517f5a6f2b38d5659484eae2aeef8ef14a7b5",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "avalonia.freedesktop.0.9.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/sharpgen.runtime/1.2.1/sharpgen.runtime.1.2.1.nupkg",
-        "sha512": "a1209eca49362d14d7f934667052e41b19b92d3931394bca83dafb7bba11bc3a7d20c0e33ed1da2280bf23a32a5d3fe07f58bb7282803db58fd4dacd77896f45",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "sharpgen.runtime.1.2.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/sharpgen.runtime.com/1.2.0/sharpgen.runtime.com.1.2.0.nupkg",
-        "sha512": "f937e02b46d918683f1615f9c1697844882e9f9e627e7e52ac91c3cae5d24c2f7846f010b528b78a8b16268ce87139f4192bfc17ce44fda1359a37a87f59e7ba",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "sharpgen.runtime.com.1.2.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/sharpdx.direct2d1/4.0.1/sharpdx.direct2d1.4.0.1.nupkg",
-        "sha512": "eb164979442f7106c96ea186414309d29671bc0eb68ad5ed0581f80b698de01c72f6deb78aca7cb67363eb0058f3a144070f2a2ae84537b7b9559d20c7e38798",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "sharpdx.direct2d1.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/sharpdx.dxgi/4.0.1/sharpdx.dxgi.4.0.1.nupkg",
-        "sha512": "5f4ff6924997374b20d99dea8089dc95cd03d45fd5b518c429b61a26be187f0d97ceafc8db0eaf26a43f2b61065ca9ae37b9b207c416b8a6fa75d4fb7fd89d09",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "sharpdx.dxgi.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/sharpdx/4.0.1/sharpdx.4.0.1.nupkg",
-        "sha512": "d41f4038aa8b5de52a541db5e9347fae835c6adfd91385ed998a7c4c242b69e8caa961b8fb3ec76b6c4b8a897a64ace9ab64778c2f120d6c39bfaa18cc368965",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "sharpdx.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/sharpdx.direct3d11/4.0.1/sharpdx.direct3d11.4.0.1.nupkg",
-        "sha512": "cd8db2621998300428223cb7bca7b8d381ec72a35aa3d85e273ccfeeffbcfe6a6035051cd3e27668e0ac567ce78c931f78e031964a9e41ff4ddbb3e9d0c786f9",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "sharpdx.direct3d11.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.skia.linux.natives/1.68.0.2/avalonia.skia.linux.natives.1.68.0.2.nupkg",
-        "sha512": "9ee9aec193c70e2b6ff56eefbdcf80b94e5cb059449b4d981010a6901be07f6ecf9729a741fdf116448c48d3e0060c3bdda14872e844f8ca7121c84794141eb7",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "avalonia.skia.linux.natives.1.68.0.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp/1.68.0/skiasharp.1.68.0.nupkg",
-        "sha512": "17c361eb0b3d58654275d41be74f5797894220ebbbf3a39cdbbb7d2f13dbb8f654ece970ea354ed97ea2aa61ebc18f8c6505d05c3e0378ae4b53cbdf88dc130a",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "skiasharp.1.68.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.security.cryptography.apple/4.3.0/runtime.native.system.security.cryptography.apple.4.3.0.nupkg",
-        "sha512": "23c6a99b323cd71cdcb28c6faa71f099f69ff0972d5125607ae8bbc99ba7c08513571d14526e8c2805ab3a8b70d3d3a6dd76dfa193320393ecb05906ee91f37d",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.native.system.security.cryptography.apple.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.requests/4.0.11/system.net.requests.4.0.11.nupkg",
-        "sha512": "22f38b1934f3276cb91a94a7d1ec20ca90b9d930820fab5853c31d2de76d6505b455c3f6e356fab11276acb84514f9f99fe6e24d75ee6067da4f24f709551ff1",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.net.requests.4.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization.extensions/4.3.0/system.globalization.extensions.4.3.0.nupkg",
-        "sha512": "a4d360003f95e0c31edf39c0b91e1c73850a60ac5d0032b17db888a3c7d7134cef9acd97219d14174ad213b7c044f49b364cc5720073ebfcb6e1bf6e4ec24ce5",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.globalization.extensions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization.extensions/4.0.1/system.globalization.extensions.4.0.1.nupkg",
-        "sha512": "415ab44aa3e46b59ad1d314ceda11f9dc78f85adede3daece96c83c98448e2a0cad7e79045edeeeaca8618115c38517364b00cdd9a0a7228e7da1ebc342b0116",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.globalization.extensions.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.diagnosticsource/4.3.0/system.diagnostics.diagnosticsource.4.3.0.nupkg",
-        "sha512": "8f54df5ff382b6650e2e10d1043863a24bf49ff0714e779e837cd7073e46fb2635bcfcdcf99d7c4a9d95f35ebffd86ab0ca068305f4b245072e08303b917b34d",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.diagnostics.diagnosticsource.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.diagnosticsource/4.0.0/system.diagnostics.diagnosticsource.4.0.0.nupkg",
-        "sha512": "199e2a85b5cb0ea6c2ce13e12444af61e80da7625c4f7d0dcc97dcc363b21f2bee48c7bcfd85d99d0a23aeb1ea35f94dd7ff8fd22ab50f2481e472a749765471",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.diagnostics.diagnosticsource.4.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.typeextensions/4.3.0/system.reflection.typeextensions.4.3.0.nupkg",
-        "sha512": "68ae81a635b9af2aee9fc8fc8fe7da0356ef4da4eb32f81a89fb75613b96714e8f1a1f4c12bd0d335efbb03408cc7a744314837f13564d5fb262ca272055677f",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.reflection.typeextensions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.typeextensions/4.1.0/system.reflection.typeextensions.4.1.0.nupkg",
-        "sha512": "5b1875ae86f76f60307fbe261c7471e996d4d4eade0c4783cb35a5aad7fec4f01be01cb1f1f78af22d483ecce12096f6ed431d69c4a66c7bf235008bcac30cb7",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.reflection.typeextensions.4.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.systemevents/4.5.0/microsoft.win32.systemevents.4.5.0.nupkg",
-        "sha512": "2b64c0af4ee9825fe6fc9f5e777726033c74483e79918b957c11ba48f4481ff10b4e1fc3daa1ab8ce583409a3bafe2d99759ced8d925d14010054b7a4b67b0a9",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.win32.systemevents.4.5.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/tmds.dbus/0.7.0/tmds.dbus.0.7.0.nupkg",
-        "sha512": "e8acb28c0935edafb403de1fda208d96e65b5a1db17193da810c9335e69a01b9f57060e9ecc704ae8ac6a161a329cfa52902437bc5ed747b1326818a9de2b0ac",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "tmds.dbus.0.7.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app/1.0.5/microsoft.netcore.app.1.0.5.nupkg",
-        "sha512": "51e0d203d3b94fce0f610f4ad466af6af10947dfeb55af43ca62819dcd8afd1f6e6080fbd7dd7307d060ce3af23e092acbdaa713003ee1c8443a48f9561388d8",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.netcore.app.1.0.5.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple/4.3.0/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg",
-        "sha512": "9929942914071e0ea0944a952ff9ad3c296be39e719a2f4bb3eac298d41829b4468b332fba880ebe242871a02145e1c26dc7660021375d12c7efcae4d200278a",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/libuv/1.9.1/libuv.1.9.1.nupkg",
-        "sha512": "156d68670a075dbc39cbb55364e7410b5c8d510037b16aeaeda04a640667e7b81a5df7dd9b1908a3ffde760da78733a5198cbbd6469fb78094147795f610c0a6",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "libuv.1.9.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.dotnethostpolicy/1.0.5/microsoft.netcore.dotnethostpolicy.1.0.5.nupkg",
-        "sha512": "90c4fe4e32d37205437df3712b9cb86ca63b6324404a4d72f7f67abb22056e05d33a74ef20a28ec3c35fa2258232d55c703244d5fa693f02b216bb1047ab74cc",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.netcore.dotnethostpolicy.1.0.5.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.runtime.coreclr/1.0.7/microsoft.netcore.runtime.coreclr.1.0.7.nupkg",
-        "sha512": "20bf4aa679bd24faba525ebdb6a46291315523625ec3c1db86b4303eaf855290d4c69599051d380eb728c586971fbe65bedca8a8a7f1c83a2f6d0542c736cf36",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.netcore.runtime.coreclr.1.0.7.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.security.cryptography/4.0.1/runtime.native.system.security.cryptography.4.0.1.nupkg",
-        "sha512": "84d6eb4e2d23f2cc758b7d8ff116a7150ed2cec4ec9663887bf672ac5e7f4b37690695c7d76e38e597059dfa65d18fd3cc945b71a4722b6f1e6a3c61672841c6",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "runtime.native.system.security.cryptography.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.thread/4.0.0/system.threading.thread.4.0.0.nupkg",
-        "sha512": "9ee52992ea7615b0785dfeb69f058046d9b5c10e39edf13247d2af2ec0b30528f5c904ed2aeaa6952830fdee9a8b00770a25040146d9d48804bf36bf9b6498c4",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.threading.thread.4.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.parallel/4.0.1/system.threading.tasks.parallel.4.0.1.nupkg",
-        "sha512": "ce0508e835a5ccbe43cc5408f7faba9820b7580e8f728f81eadc8b963cef7998ac89a5228195cae541a6d0a283a824cf8c6e2151110d049d8433a563407b8c6c",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.threading.tasks.parallel.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.dataflow/4.6.0/system.threading.tasks.dataflow.4.6.0.nupkg",
-        "sha512": "53e595bfe324522e53ecf337c890fb5ac5f4a6797335c334f2bfae6b63f9329bc65efebd0c4fb76c17e1773f14e99c6f3ed864bc3beacbf01a23166128a81477",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.threading.tasks.dataflow.4.6.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.loader/4.0.0/system.runtime.loader.4.0.0.nupkg",
-        "sha512": "0065abcb02c8d81d79fdd9cbb859e51d61635e6ab54e5d248d668a4c76da27c4fd908c6243c6064ed88c41cf2b52be3d9762637d96bb418d0a2aa972cc0ecd36",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.runtime.loader.4.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.resources.reader/4.0.0/system.resources.reader.4.0.0.nupkg",
-        "sha512": "cf88c486ea14ab083f0b78c040d7ffefdbd07ba3b20fb0fb335867a0c4fa0f79185a983f710f60ff9b36a1b442ae0fb80f1682fcade80347c2b0150a46bca093",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.resources.reader.4.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.metadata/1.3.0/system.reflection.metadata.1.3.0.nupkg",
-        "sha512": "a62b9a3b2d191f5fe734731dc05ac73f6ed3a18ed255b94ca9cfaef281157f8df821ca4c996a6e53d6975a10257916239ca99f077548bc6b301308b0a6db9e5e",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.reflection.metadata.1.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.dispatchproxy/4.0.1/system.reflection.dispatchproxy.4.0.1.nupkg",
-        "sha512": "da76cbd8e9c688233bfe56e20063a04f785754794b75f6078b1affd66e8678805de37c0b20b03c24dcd856f2c29dee2e68b4a95d45e4686cfa9e31e70935f5d6",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.reflection.dispatchproxy.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.numerics.vectors/4.1.1/system.numerics.vectors.4.1.1.nupkg",
-        "sha512": "dd3cfd6017028fd348f96b898a756909f24530cd0754af04d40c8ceff75676fcefa7b5dba4d7e713735622712a991c7610385785252c56287ed238f6dfd1a453",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.numerics.vectors.4.1.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.security/4.0.1/system.net.security.4.0.1.nupkg",
-        "sha512": "eb56305c0b5506791f32a2c8b5e5e7c3f7394420f62c6371c161a70eea671823cfccafafea8c0ecabcb5615a004d89b7a5aa41d693cc6c8b27811a5185e6aba3",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.net.security.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.webheadercollection/4.0.1/system.net.webheadercollection.4.0.1.nupkg",
-        "sha512": "d1a2e5f3269a1fefe3c88d1fd4c9fdc4ebc1596c3239a266fe947648f00dd91bf18530ffcb1c4f699b7977ed8a5c065d3e424e69f4b8410d4669785970c375ea",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.net.webheadercollection.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.csharp/4.0.1/microsoft.csharp.4.0.1.nupkg",
-        "sha512": "c0e75a9162f28ba4c4572c8fac4fd4c8c97d6d3505a37683646ba5f7e5f6ac0da69d5200d2646054de90e8e08f893a10e514591b69b8273640842b2cf90bddec",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.csharp.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.visualbasic/10.0.1/microsoft.visualbasic.10.0.1.nupkg",
-        "sha512": "6ba8407fc013e5bea5614036f889fcf2983af3dc0a74a42d8d20498f9146cacba5cb7c236399ef58dde9c0a3612d0d95e8ab43fb42bb9fa427895e8d68dc8347",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.visualbasic.10.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.collections.immutable/1.2.0/system.collections.immutable.1.2.0.nupkg",
-        "sha512": "0021795a155f67f1247e6572f70a5cde82422bb9288751a59d74385975bd378ae26f363c68a17a56be7a8c3d2b353b94cc5bd15836c7b9827f427aedaddffb54",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.collections.immutable.1.2.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.componentmodel/4.0.1/system.componentmodel.4.0.1.nupkg",
-        "sha512": "b4de433cc620eb214ee651792f9845e932190dc450ffe7f561c5c63fccb6632e3def55e8c4f38b1f896490bdb4bfacdbe1a015b29fb1ae4470ccc15e479647ab",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.componentmodel.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.process/4.1.0/system.diagnostics.process.4.1.0.nupkg",
-        "sha512": "4b6602f8cc29599e9eee1da5a8d71efee6cc8c3e2f7f611afee3849dc60d1f5fdf15769794a0ccf6283fcc2135ad1fb0c18cc4f055edbe3fb53729a1ea867d6e",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.diagnostics.process.4.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.dynamic.runtime/4.0.11/system.dynamic.runtime.4.0.11.nupkg",
-        "sha512": "0b2189a6f50effab44a8b1f883f2a1f9b9b32c448123190e8946a877c28ff46a235aa90af0898d1ccd6da2f3155aa2cf26e57f7f61ee7e3c50dfde2190d781ab",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.dynamic.runtime.4.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.filesystem.watcher/4.0.0/system.io.filesystem.watcher.4.0.0.nupkg",
-        "sha512": "8f260e535c69de59c4e18cdeef9e5523b06701f76d3ffb5b93ec05abbd69c5f68ca83f09c5c43bd40f6ddeef407526a8dca2a7a7ce0901561240ca5faec077fd",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.io.filesystem.watcher.4.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.memorymappedfiles/4.0.0/system.io.memorymappedfiles.4.0.0.nupkg",
-        "sha512": "a1e30430cc3362849a6ba741d703e9a03fc8b52590d225d0689ac624f9da7af02fcac992891e51a7ed5a007482bdc8e55ed322c8eda7fbf784450deaafb69c75",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.io.memorymappedfiles.4.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.unmanagedmemorystream/4.0.1/system.io.unmanagedmemorystream.4.0.1.nupkg",
-        "sha512": "e15b96f0a2b835a6e470ef5f85b890172bc4e85afd8e80e61b344de8006af5e5f6d63fcd7fcf0f28efcf3173adb43f9af6b473cda6a79c45dfd7d194543ce135",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.io.unmanagedmemorystream.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.linq.parallel/4.0.1/system.linq.parallel.4.0.1.nupkg",
-        "sha512": "f74824d2b288ef26e33855894bfb13d09674848f00850b1e6e4f7199dc377afe5e9c96a9127d0e757540c05342ea8bf1e0cd1f4983ecadef2a91c432a47f50cf",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.linq.parallel.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.linq.queryable/4.0.1/system.linq.queryable.4.0.1.nupkg",
-        "sha512": "e658e45e86fe826988cb0e053a78ef85b8ba8ea348173979b7d705a35d7e993c3e7c1bbb2aacd139511e3e305a0d4a4b87a4fd299038e9543e6338fe31c07fe3",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "system.linq.queryable.4.0.1.nupkg"
-    },
-        {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/3.1.6/microsoft.netcore.app.runtime.linux-x64.3.1.6.nupkg",
-        "sha512": "5d1ca7a1bcf421a8a2ea723c96d0e4aa6bbd03054ed2d4a9f934a32f72fe5c343d6b2dde0bea235baa8323cb760a9f6846278ca9f420859e066a135c8b1b2114",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.netcore.app.runtime.linux-x64.3.1.6.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/3.1.6/microsoft.aspnetcore.app.runtime.linux-x64.3.1.6.nupkg",
-        "sha512": "0f615df40bd1dbc99f7bbda958ab78414e0f66c53b4068d7fba2802cac8f7c2edbc67507d8a0185e12df69f1bc4f475faf7ee25463da2672e99222c4dd030d53",
-        "dest": "LocalNugetPackages",
-        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.3.1.6.nupkg"
+        "url": "https://api.nuget.org/v3-flatcontainer/tmds.dbus/0.9.0/tmds.dbus.0.9.0.nupkg",
+        "sha512": "20e3b4f03fd666a499e89948db9ebdd1fddfd6523685622823dbbc5c2cf933bbc43a5082f9ac174186701e716d72a31737cffa02ac9539692d71e45449f9184c",
+        "dest": "nuget-sources",
+        "dest-filename": "tmds.dbus.0.9.0.nupkg"
     }
 ]

--- a/sources.json
+++ b/sources.json
@@ -1,6 +1,20 @@
 [
     {
         "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/6.0.14/microsoft.aspnetcore.app.runtime.linux-x64.6.0.14.nupkg",
+        "sha512": "d10f0e53ac2872fdad7c2f5efc4ead7326ba92bf63ca7a4db473eb9940d0a39f513548ddf7ddfaf114c4724a4ef3b8a7180b8a51aa9a5ffc2938d81db8b4e473",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.6.0.14.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/6.0.14/microsoft.netcore.app.runtime.linux-x64.6.0.14.nupkg",
+        "sha512": "0168110952af6f3c3de82385d3638ee9bf35df0dd7f51042f5a70acf26d56d0403a2f1c07fc96fd7327726c2d9b624fd244b7ed335907a94e30723c2e6b881eb",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.netcore.app.runtime.linux-x64.6.0.14.nupkg"
+    },
+    {
+        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/autofac/6.5.0/autofac.6.5.0.nupkg",
         "sha512": "cb8cf3e770d0924fdac19f884cc569e2f93639f57538f0097b7b019b54624f8c1530f1bd0efd1edecac8a95d41c75d105dab4bb32dcb935a4714835b8a3f9e0f",
         "dest": "nuget-sources",

--- a/stationhub.sh
+++ b/stationhub.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-/app/org.unitystation.StationHub/StationHub

--- a/stationhub.sh
+++ b/stationhub.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-/app/dotnet/bin/dotnet /app/org.unitystation.StationHub/StationHub.dll
+/app/org.unitystation.StationHub/StationHub


### PR DESCRIPTION
- Updates runtime version to 22.08 ( Fixes #1 )
- Updates StationHub version to the latest
  - Changes repo URL from fork to the main upstream repo as the changes for the Flatpak have been merged there already
- Changes the build to use `--self-contained` to get rid of the need for stationhub.sh
- Updates version of iputils to the latest, removing deprecated build flags
- Changes SDK from org.freedesktop.Sdk.Extension.dotnet to org.freedesktop.Sdk.Extension.dotnet6