### PR TITLE
Update the runtime version from 24.08 to 25.08, and more

### DIFF
--- a/org.unitystation.StationHub.yaml
+++ b/org.unitystation.StationHub.yaml
@@ -1,6 +1,6 @@
 app-id: org.unitystation.StationHub
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: StationHub
 sdk-extensions:
@@ -22,7 +22,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/iputils/iputils
-        tag: 20221126
+        tag: '20221126'
         commit: 5ffabc4190cab975c7332645259e286a032e183b
   - name: StationHub
     sources:
@@ -35,9 +35,7 @@ modules:
     buildsystem: simple
     build-commands:
       - '. /usr/lib/sdk/dotnet8/enable.sh; dotnet publish --framework net8.0 --runtime linux-x64 --configuration Release --self-contained true --source ./nuget-sources --property PublishDir=/app/bin ./UnitystationLauncher/UnitystationLauncher.csproj /p:DisableBeauty=true'
-      - install -D UnitystationLauncher/Assets/org.unitystation.StationHub.desktop /app/share/applications/org.unitystation.StationHub.desktop
-      - install -D UnitystationLauncher/Assets/Ian64.png /app/share/icons/hicolor/64x64/apps/org.unitystation.StationHub.png
-      - install -D UnitystationLauncher/Assets/Ian128.png /app/share/icons/hicolor/128x128/apps/org.unitystation.StationHub.png
-      - install -D UnitystationLauncher/Assets/Ian256.png /app/share/icons/hicolor/256x256/apps/org.unitystation.StationHub.png
-      - install -D UnitystationLauncher/Assets/Ian512.png /app/share/icons/hicolor/512x512/apps/org.unitystation.StationHub.png
-      - install -D UnitystationLauncher/Assets/org.unitystation.StationHub.metainfo.xml /app/share/metainfo/org.unitystation.StationHub.metainfo.xml
+      - install -D UnitystationLauncher/Assets/${FLATPAK_ID}.desktop -t /app/share/applications/
+      - install -D UnitystationLauncher/Assets/Ian256.png /app/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png
+      - install -D UnitystationLauncher/Assets/Ian512.png /app/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png
+      - install -D UnitystationLauncher/Assets/${FLATPAK_ID}.metainfo.xml -t /app/share/metainfo/

--- a/sources.json
+++ b/sources.json
@@ -1,10 +1,10 @@
 [
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/8.0.12/microsoft.aspnetcore.app.runtime.linux-x64.8.0.12.nupkg",
-        "sha512": "ebbcad53109c0f2682995908a372796c284528325fdc222324cb4127ed709da1aac9abe81ecf5cde419ea6956ef853b2c5b76e287342df923186d31faf70c430",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/8.0.26/microsoft.aspnetcore.app.runtime.linux-x64.8.0.26.nupkg",
+        "sha512": "10d70cae4070bd57fb140f41c6f67ac583e0a509073c1403cf67b17e2ab902a087601a831430115797980c00c756a4865e4861a41ee423de583e8671405bbf08",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.6.0.14.nupkg"
+        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.8.0.26.nupkg"
     },
     {
         "type": "file",
@@ -645,10 +645,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/8.0.12/microsoft.netcore.app.runtime.linux-x64.8.0.12.nupkg",
-        "sha512": "8da9fabc64fbbe0f1f6ed3722679849378d83536d19f3c71d9bdfb44c6526ae6fde872e744045ef041edfa51668f2c63dfd0510bd8b3af15b518311479bcfaac",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/8.0.26/microsoft.netcore.app.runtime.linux-x64.8.0.26.nupkg",
+        "sha512": "a0a53c38d9c16a16cf7282a9998f4132098ef9772002f84cb94bb0ce1b58a6c9f0465f31060b2dd3bca7812ce7348422703eb425ca01930ba5b91156058938e9",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.runtime.linux-x64.8.0.12.nupkg"
+        "dest-filename": "microsoft.netcore.app.runtime.linux-x64.8.0.26.nupkg"
     },
     {
         "type": "file",


### PR DESCRIPTION
- Update the runtime version to 25.08
- Simplify the install commands
- Update two dependencies to fix build error
- Comply with Flathub styling guidelines

See: https://docs.flathub.org/docs/for-app-authors/requirements#flatpak-builder-manifest-style-guide